### PR TITLE
connect() method can use NEOVIM_LISTEN_ADDRESS 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Open the python REPL with another terminal connect to Neovim:
 [1, 2, 3]
 ```
 
+If you have defined NEOVIM_LISTEN_ADDRESS globally, you can use
+
+```
+>>> import neovim
+>>> vim = neovim.connect()
+>>> ...
+```
+
 See the test subdirectory for more examples
 
 This is still alpha and incomplete, use only for testing purposes

--- a/neovim/__init__.py
+++ b/neovim/__init__.py
@@ -18,9 +18,9 @@ class NullHandler(logging.Handler):
 
 def connect(address=None, port=None, vim_compatible=False):
     if address is None:
-        address = os.environ.get('NEOVIM_LISTEN_ADDRESS', False)
+        address = os.environ.get('NVIM_LISTEN_ADDRESS', False)
         if not address:
-            raise Exception('No NEOVIM_LISTEN_ADDRESS value found!')
+            raise Exception('No NVIM_LISTEN_ADDRESS value found!')
     client = Client(RPCStream(MsgpackStream(UvStream(address, port))),
                     vim_compatible)
     client.discover_api()

--- a/neovim/__init__.py
+++ b/neovim/__init__.py
@@ -17,6 +17,10 @@ class NullHandler(logging.Handler):
 
 
 def connect(address=None, port=None, vim_compatible=False):
+    if address is None:
+        address = os.environ.get('NEOVIM_LISTEN_ADDRESS', False)
+        if not address:
+            raise Exception('No NEOVIM_LISTEN_ADDRESS value found!')
     client = Client(RPCStream(MsgpackStream(UvStream(address, port))),
                     vim_compatible)
     client.discover_api()


### PR DESCRIPTION
Hi @tarruda 

Thanks for this library, i just improve the possibility to use the NEOVIM_LISTEN_ADDRESS in connect() method if address is empty, with this improvement we can directly execute python script in neovim like (neovim set NEOVIM_LISTEN_ADDRESS if not exists)

```
:! python myscript.py
```

Regards,
