### PR TITLE
Python3 fixes: functools.partial and encoding

### DIFF
--- a/neovim/plugin/decorators.py
+++ b/neovim/plugin/decorators.py
@@ -1,8 +1,10 @@
 """Decorators used by python host plugin system."""
+
 import inspect
-
-
 import logging
+
+from ..compat import IS_PYTHON3
+
 logger = logging.getLogger(__name__)
 debug, info, warn = (logger.debug, logger.info, logger.warn,)
 __all__ = ('plugin', 'rpc_export', 'command', 'autocmd', 'function',
@@ -20,8 +22,11 @@ def plugin(cls):
     # decorated functions have a bound Nvim instance as first argument.
     # For methods in a plugin-decorated class this is not required, because
     # the class initializer will already receive the nvim object.
-    for _, fn in inspect.getmembers(cls, inspect.ismethod):
-        if hasattr(fn, '_nvim_bind'):
+    predicate = lambda fn: hasattr(fn, '_nvim_bind')
+    for _, fn in inspect.getmembers(cls, predicate):
+        if IS_PYTHON3:
+            fn._nvim_bind = False
+        else:
             fn.im_func._nvim_bind = False
     return cls
 

--- a/neovim/plugin/host.py
+++ b/neovim/plugin/host.py
@@ -37,6 +37,8 @@ class Host(object):
             'shutdown': self.shutdown
         }
         self._nvim_encoding = nvim.options['encoding']
+        if IS_PYTHON3 and isinstance(self._nvim_encoding, bytes):
+            self._nvim_encoding = self._nvim_encoding.decode('ascii')
 
     def start(self, plugins):
         """Start listening for msgpack-rpc requests and notifications."""
@@ -51,6 +53,8 @@ class Host(object):
 
     def _on_request(self, name, args):
         """Handle a msgpack-rpc request."""
+        if IS_PYTHON3 and isinstance(name, bytes):
+            name = name.decode(self._nvim_encoding)
         handler = self._request_handlers.get(name, None)
         if not handler:
             msg = 'no request handler registered for "%s"' % name
@@ -64,6 +68,8 @@ class Host(object):
 
     def _on_notification(self, name, args):
         """Handle a msgpack-rpc notification."""
+        if IS_PYTHON3 and isinstance(name, bytes):
+            name = name.decode(self._nvim_encoding)
         handler = self._notification_handlers.get(name, None)
         if not handler:
             warn('no notification handler registered for "%s"', name)


### PR DESCRIPTION
- Partial fix for neovim/neovim#1829
- I'm a bit at lost as to why the functools.partial is being used here, It
  clearly does not work for Python3, but it is not clear to me what is it
  supposed to be doing @tarruda?
- Encoding names in Python3 need to be strings, fixes Host._nvim_encoding
- Binary strings from msgpack are decoded as the bytes type, but rpc method
  names used by rpc_export are unicode strings, this causes a comparison
  between the request names and the exported functions to fail (use &encoding
  to decode)
