### PR TITLE
Provide exception traceback in error response

### DIFF
--- a/neovim/msgpack_rpc/session.py
+++ b/neovim/msgpack_rpc/session.py
@@ -172,7 +172,7 @@ class Session(object):
             except Exception as err:
                 warn("error caught while processing request '%s %s': %s", name,
                      args, format_exc())
-                response.send(repr(err), error=True)
+                response.send(repr(err) + "\n" + format_exc(5), error=True)
             debug('greenlet %s is now dying...', gr)
 
         # Create a new greenlet to handle the request


### PR DESCRIPTION
While NVIM_PYTHON_LOG_FILE can be used to retrieve these, it seems to be
more convenient to know where an error is coming from.

Maybe only `format_exc` should be used.  Please feel free to adopt it as needed.