### PR TITLE
[RFC] api: make remote objects hashable on their identity

### DIFF
--- a/neovim/api/common.py
+++ b/neovim/api/common.py
@@ -15,6 +15,10 @@ class Remote(object):
         return (hasattr(other, 'code_data') and
                 other.code_data == self.code_data)
 
+    def __hash__(self):
+        """Return hash based on remote object id."""
+        return self.code_data.__hash__()
+
 
 class RemoteMap(object):
 

--- a/test/test_vim.py
+++ b/test/test_vim.py
@@ -124,3 +124,17 @@ def test_tabpages():
     vim.current.tabpage = vim.tabpages[1]
     eq(vim.tabpages[1], vim.current.tabpage)
     eq(vim.windows[1], vim.current.window)
+
+
+@with_setup(setup=cleanup)
+def test_hash():
+    d = {}
+    d[vim.current.buffer] = "alpha"
+    eq(d[vim.current.buffer], "alpha")
+    vim.command('new')
+    d[vim.current.buffer] = "beta"
+    eq(d[vim.current.buffer], "beta")
+    vim.command('winc w')
+    eq(d[vim.current.buffer], "alpha")
+    vim.command('winc w')
+    eq(d[vim.current.buffer], "beta")


### PR DESCRIPTION
Useful for associating data with a buffer purely on the python side.