### PR TITLE
[RFC] allow async method calls to nvim

### DIFF
--- a/neovim/api/common.py
+++ b/neovim/api/common.py
@@ -224,11 +224,11 @@ class SessionFilter(object):
         if msg:
             return walk(self._in, msg, self, msg[1], msg[0])
 
-    def request(self, name, *args):
+    def request(self, name, *args, **kwargs):
         """Wrapper for Session.request."""
         args = walk(self._out, args, self, name, 'out-request')
-        return walk(self._in, self._session.request(name, *args), self, name,
-                    'out-request')
+        return walk(self._in, self._session.request(name, *args, **kwargs),
+                    self, name, 'out-request')
 
     def run(self, request_cb, notification_cb, setup_cb=None):
         """Wrapper for Session.run."""

--- a/neovim/api/nvim.py
+++ b/neovim/api/nvim.py
@@ -112,17 +112,17 @@ class Nvim(object):
         """Unsubscribe to a Nvim event."""
         return self._session.request('vim_unsubscribe', event)
 
-    def command(self, string):
+    def command(self, string, async=False):
         """Execute a single ex command."""
-        return self._session.request('vim_command', string)
+        return self._session.request('vim_command', string, async=async)
 
     def command_output(self, string):
         """Execute a single ex command and return the output."""
         return self._session.request('vim_command_output', string)
 
-    def eval(self, string):
+    def eval(self, string, async=False):
         """Evaluate a vimscript expression."""
-        return self._session.request('vim_eval', string)
+        return self._session.request('vim_eval', string, async=async)
 
     def strwidth(self, string):
         """Return the number of display cells `string` occupies.

--- a/neovim/msgpack_rpc/async_session.py
+++ b/neovim/msgpack_rpc/async_session.py
@@ -44,6 +44,15 @@ class AsyncSession(object):
         self._msgpack_stream.send([0, request_id, method, args])
         self._pending_requests[request_id] = response_cb
 
+    def notify(self, method, args):
+        """Send a msgpack-rpc notification to Nvim.
+
+        A msgpack-rpc with method `method` and argument `args` is sent to
+        Nvim. This will have the same effect as a request, but no response
+        will be recieved
+        """
+        self._msgpack_stream.send([2, method, args])
+
     def run(self, request_cb, notification_cb):
         """Run the event loop to receive requests and notifications from Nvim.
 

--- a/neovim/msgpack_rpc/session.py
+++ b/neovim/msgpack_rpc/session.py
@@ -54,7 +54,7 @@ class Session(object):
         if self._pending_messages:
             return self._pending_messages.popleft()
 
-    def request(self, method, *args):
+    def request(self, method, *args, **kwargs):
         """Send a msgpack-rpc request and block until as response is received.
 
         If the event loop is running, this method must have been called by a
@@ -67,7 +67,16 @@ class Session(object):
         - Send the request
         - Run the loop until the response is available
         - Put requests/notifications received while waiting into a queue
+
+        If the `async` flag is present and True, a asynchronous notification is
+        sent instead. This will never block, and the return value or error is
+        ignored.
         """
+        async = kwargs.get('async', False)
+        if async:
+            self._async_session.notify(method, args)
+            return
+
         if self._is_running:
             v = self._yielding_request(method, args)
         else:

--- a/test/test_client_rpc.py
+++ b/test/test_client_rpc.py
@@ -35,6 +35,19 @@ def test_call_api_before_reply():
 
     vim.session.run(request_cb, None, setup_cb)
 
+@with_setup(setup=cleanup)
+def test_async_call():
+
+    def request_cb(name, args):
+        vim.vars['result'] = 17
+        vim.session.stop()
+
+    cmd = 'call rpcrequest(%d, "test-event")' % vim.channel_id
+    # this would have dead-locked if not async
+    vim.session.request('vim_command', cmd, async=True)
+    vim.session.run(request_cb, None, None)
+    eq(vim.vars['result'], 17)
+
 
 @with_setup(setup=cleanup)
 def test_recursion():

--- a/test/test_client_rpc.py
+++ b/test/test_client_rpc.py
@@ -42,9 +42,8 @@ def test_async_call():
         vim.vars['result'] = 17
         vim.session.stop()
 
-    cmd = 'call rpcrequest(%d, "test-event")' % vim.channel_id
     # this would have dead-locked if not async
-    vim.session.request('vim_command', cmd, async=True)
+    vim.eval('rpcrequest(%d, "test-event")' % vim.channel_id, async=True)
     vim.session.run(request_cb, None, None)
     eq(vim.vars['result'], 17)
 

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -19,15 +19,15 @@ def test_receiving_events():
 @with_setup(setup=cleanup)
 def test_sending_notify():
     # notify after notify
-    vim.session.request('vim_command', "let g:test = 3", async=True)
+    vim.command("let g:test = 3", async=True)
     cmd = 'call rpcnotify(%d, "test-event", g:test)' % vim.channel_id
-    vim.session.request('vim_command', cmd, async=True)
+    vim.command(cmd, async=True)
     event = vim.session.next_message()
     eq(event[1], 'test-event')
     eq(event[2], [3])
 
     # request after notify
-    vim.session.request('vim_command', "let g:data = 'xyz'", async=True)
+    vim.command("let g:data = 'xyz'", async=True)
     eq(vim.eval('g:data'), 'xyz')
 
 

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -16,6 +16,20 @@ def test_receiving_events():
     eq(event[1], 'py!')
     eq(event[2], [vim.current.buffer.number])
 
+@with_setup(setup=cleanup)
+def test_sending_notify():
+    # notify after notify
+    vim.session.request('vim_command', "let g:test = 3", async=True)
+    cmd = 'call rpcnotify(%d, "test-event", g:test)' % vim.channel_id
+    vim.session.request('vim_command', cmd, async=True)
+    event = vim.session.next_message()
+    eq(event[1], 'test-event')
+    eq(event[2], [3])
+
+    # request after notify
+    vim.session.request('vim_command', "let g:data = 'xyz'", async=True)
+    eq(vim.eval('g:data'), 'xyz')
+
 
 @with_setup(setup=cleanup)
 def test_broadcast():


### PR DESCRIPTION
Allows to call neovim rpc methods asynchronously. This is useful to be able to make a lot of calls without requiring 2 context switches per call. For instance for `bufhl` a rich highlighter might make thousands of `buffer_add_highlight` at once for a big file.
Not sure of the api though, perhaps `vim.session.request(..., async=True)` is better?