### PR TITLE
[RFC] Use separate log files for different clients

### DIFF
--- a/neovim/__init__.py
+++ b/neovim/__init__.py
@@ -45,7 +45,8 @@ def start_host(session=None):
 
     logger = logging.getLogger(__name__)
     if 'NVIM_PYTHON_LOG_FILE' in os.environ:
-        logfile = os.environ['NVIM_PYTHON_LOG_FILE'].strip()
+        logfile = (os.environ['NVIM_PYTHON_LOG_FILE'].strip() +
+                   '_' + str(os.getpid()))
         handler = logging.FileHandler(logfile, 'w')
         handler.formatter = logging.Formatter(
             '%(asctime)s [%(levelname)s @ '


### PR DESCRIPTION
Before it was not possible to reliably capture the log file in a realistic situation where both legacy python provider and rplugin host are used, and both will compete for the same `NVIM_PYTHON_LOG_FILE`

This is the "ugly hack" solution, more informative might be to append the channel number, as error messages inside nvim typically report this, but that would require some restructuring as this is not available yet here.