### PR TITLE
Scrutinizer: Increase timeout for code coverage data

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -130,5 +130,5 @@ filter:
 
 tools:
   external_code_coverage:
-    timeout: 600
+    timeout: 1200
     runs: 6


### PR DESCRIPTION
Previously, scrutinizer often fails due to travis not delivering data in time