### PR TITLE
[RFC] Python 3 host: Handle byte strings for specs requests.

### DIFF
--- a/neovim/plugin/host.py
+++ b/neovim/plugin/host.py
@@ -33,7 +33,7 @@ class Host(object):
         self._notification_handlers = {}
         self._request_handlers = {
             'poll': lambda: 'ok',
-            'specs': lambda path: self._specs.get(path, []),
+            'specs': self._on_specs_request,
             'shutdown': self.shutdown
         }
         self._nvim_encoding = nvim.options['encoding']
@@ -155,6 +155,11 @@ class Host(object):
             handlers.append(fn)
         if specs:
             self._specs[plugin_path] = specs
+
+    def _on_specs_request(self, path):
+        if IS_PYTHON3 and isinstance(path, bytes):
+            path = path.decode(self._nvim_encoding)
+        return self._specs.get(path, [])
 
     def _configure_nvim_for(self, obj):
         # Configure a nvim instance for obj(checks encoding configuration)


### PR DESCRIPTION
@Shougo does this work for you?

Possible alternative:

```diff
diff --git a/neovim/plugin/host.py b/neovim/plugin/host.py
index 2526394..2fb2fcb 100644
--- a/neovim/plugin/host.py
+++ b/neovim/plugin/host.py
@@ -61,6 +61,9 @@ class Host(object):
             warn(msg)
             raise Exception(msg)
 
+        if IS_PYTHON3:
+            args = [arg.decode(self._nvim_encoding) if isinstance(arg, bytes)
+                    else arg for arg in args]
         debug('calling request handler for "%s", args: "%s"', name, args)
         rv = handler(*args)
         debug("request handler for '%s %s' returns: %s", name, args, rv)
@@ -75,6 +78,9 @@ class Host(object):
             warn('no notification handler registered for "%s"', name)
             return
 
+        if IS_PYTHON3:
+            args = [arg.decode(self._nvim_encoding) if isinstance(arg, bytes)
+                    else arg for arg in args]
         debug('calling notification handler for "%s", args: "%s"', name, args)
         handler(*args)
```