### PR TITLE
[RFC] setup: Fix pynvim dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if not platform.python_implementation() == 'PyPy':
 
 if sys.version_info < (3, 0):
     # Experimental GUI only supported for Python 2.
-    extras_require['GUI'] = ['click>=3.0', 'cairo', 'gobject']
+    extras_require['GUI'] = ['click>=3.0', 'pygobject']
     entry_points['console_scripts'] = ['pynvim=neovim.ui.cli:main [GUI]']
 
 setup(name='neovim',


### PR DESCRIPTION
Looks like I messed up the dependencies in #116 :-S

On my system, pycairo doesn't have an egg info, so there's no other way than to just remove the dependency from the setup.py?

Tested with `pip2 install . --user --upgrade && ~/.local/bin/pynvim`