### PR TITLE
handle decoding for rplugin methods the same as for api calls

### DIFF
--- a/neovim/api/common.py
+++ b/neovim/api/common.py
@@ -180,6 +180,13 @@ class DecodeHook(SessionHook):
             return obj.decode(self.encoding, errors=self.encoding_errors)
         return obj
 
+    def walk(self, obj):
+        """Decode bytes found in obj (any msgpack object).
+
+        Uses encoding and policy specified in constructor.
+        """
+        return walk(self._decode_if_bytes, obj, None, None, None)
+
 
 class SessionFilter(object):
 

--- a/neovim/plugin/decorators.py
+++ b/neovim/plugin/decorators.py
@@ -73,7 +73,7 @@ def command(name, nargs=0, complete=None, range=None, count=None, bang=False,
         if eval:
             opts['eval'] = eval
 
-        f.nvim_rpc_spec = {
+        f._nvim_rpc_spec = {
             'type': 'command',
             'name': name,
             'sync': sync,
@@ -98,7 +98,7 @@ def autocmd(name, pattern='*', sync=False, eval=None):
         if eval:
             opts['eval'] = eval
 
-        f.nvim_rpc_spec = {
+        f._nvim_rpc_spec = {
             'type': 'autocmd',
             'name': name,
             'sync': sync,
@@ -124,7 +124,7 @@ def function(name, range=False, sync=False, eval=None):
         if eval:
             opts['eval'] = eval
 
-        f.nvim_rpc_spec = {
+        f._nvim_rpc_spec = {
             'type': 'function',
             'name': name,
             'sync': sync,


### PR DESCRIPTION
In a python3 rplugin, per default, return values from api functions like `nvim.eval()` will return unicode strings while args to rpc functions (`@neovim.function` etc)  will be passed as bytes, which is inconsistent and surprising. This PR fixes so that args to rpc functions will be decoded the same way, and this can be overidden by `@neovim.encoding` dectorator on the plugin (or individual method) the same way. No change of defaults for python2, where behaviour already is consistent.

ping @shougo @razvanc87 and others developing python3 plugins.