### PR TITLE
[RFC] expose vim_call_function

### DIFF
--- a/neovim/api/nvim.py
+++ b/neovim/api/nvim.py
@@ -126,9 +126,13 @@ class Nvim(object):
         """Evaluate a vimscript expression."""
         return self._session.request('vim_eval', string, async=async)
 
-    def call(self, name, *args):
+    def call(self, name, *args, **kwargs):
         """Call a vimscript function."""
-        return self._session.request('vim_call_function', name, args)
+        for k in kwargs:
+            if k != "async":
+                raise TypeError(
+                    "call() got an unexpected keyword argument '{}'".format(k))
+        return self._session.request('vim_call_function', name, args, **kwargs)
 
     def strwidth(self, string):
         """Return the number of display cells `string` occupies.

--- a/test/test_client_rpc.py
+++ b/test/test_client_rpc.py
@@ -39,11 +39,12 @@ def test_call_api_before_reply():
 def test_async_call():
 
     def request_cb(name, args):
-        vim.vars['result'] = 17
+        if name == "test-event":
+            vim.vars['result'] = 17
         vim.session.stop()
 
     # this would have dead-locked if not async
-    vim.eval('rpcrequest(%d, "test-event")' % vim.channel_id, async=True)
+    vim.funcs.rpcrequest(vim.channel_id, "test-event", async=True)
     vim.session.run(request_cb, None, None)
     eq(vim.vars['result'], 17)
 

--- a/test/test_vim.py
+++ b/test/test_vim.py
@@ -3,6 +3,13 @@ import os, tempfile
 from nose.tools import with_setup, eq_ as eq, ok_ as ok
 from common import vim, cleanup
 
+def source(code):
+    fd, fname = tempfile.mkstemp()
+    with os.fdopen(fd,'w') as f:
+        f.write(code)
+    vim.command('source '+fname)
+    os.unlink(fname)
+
 
 @with_setup(setup=cleanup)
 def test_command():
@@ -28,6 +35,16 @@ def test_eval():
     vim.command('let g:v1 = "a"')
     vim.command('let g:v2 = [1, 2, {"v3": 3}]')
     eq(vim.eval('g:'), {'v1': 'a', 'v2': [1, 2, {'v3': 3}]})
+
+@with_setup(setup=cleanup)
+def test_call():
+    eq(vim.funcs.join(['first', 'last'], ', '), 'first, last')
+    source("""
+        function! Testfun(a,b)
+            return string(a:a).":".a:b
+        endfunction
+    """)
+    eq(vim.funcs.Testfun(3, 'alpha'), '3:alpha')
 
 
 @with_setup(setup=cleanup)


### PR DESCRIPTION
This exposes a method call syntax for calling vimscript functions

    nvim.viml.MyVimscriptFunction(args)

Not sure `viml` is the best name. And what happens if we support async calls, would it be `nvim.viml_async.Func(...)` or `nvim.viml.Func(..., async=True)`. ?