### PR TITLE
[RFC] Don't override the encoding of msgpack STRings

### DIFF
--- a/neovim/api/nvim.py
+++ b/neovim/api/nvim.py
@@ -46,9 +46,6 @@ class Nvim(object):
         session.error_wrapper = lambda e: NvimError(e[1])
         channel_id, metadata = session.request(b'vim_get_api_info')
 
-        encoding = session.request(b'vim_get_option', b'encoding')
-        session._async_session._msgpack_stream.set_packer_encoding(encoding)
-
         if IS_PYTHON3:
             hook = DecodeHook()
             # decode all metadata strings for python3

--- a/neovim/msgpack_rpc/msgpack_stream.py
+++ b/neovim/msgpack_rpc/msgpack_stream.py
@@ -19,13 +19,9 @@ class MsgpackStream(object):
     def __init__(self, event_loop):
         """Wrap `event_loop` on a msgpack-aware interface."""
         self._event_loop = event_loop
-        self._packer = Packer(use_bin_type=True, encoding=None)
+        self._packer = Packer(use_bin_type=True)
         self._unpacker = Unpacker()
         self._message_cb = None
-
-    def set_packer_encoding(self, encoding):
-        """Switch encoding for Unicode strings."""
-        self._packer = Packer(use_bin_type=True, encoding=encoding)
 
     def threadsafe_call(self, fn):
         """Wrapper around `BaseEventLoop.threadsafe_call`."""


### PR DESCRIPTION
This is defined to be `utf-8` per msgpack spec and was already the default in `msgpack.Packer`.
Might fix neovim/neovim#3618