### PR TITLE
convert byte strings in python3 to fix #145

### DIFF
--- a/neovim/ui/cli.py
+++ b/neovim/ui/cli.py
@@ -5,7 +5,8 @@ import click
 
 from .ui_bridge import UIBridge
 from .. import attach
-
+from ..api import DecodeHook
+from ..compat import IS_PYTHON3
 
 @click.command(context_settings=dict(allow_extra_args=True))
 @click.option('--prog')
@@ -57,6 +58,11 @@ def main(ctx, prog, notify, listen, connect, profile):
         # spawn embedded instance
         nvim_argv = shlex.split(prog or 'nvim --embed') + ctx.args
         nvim = attach('child', argv=nvim_argv)
+
+    if IS_PYTHON3:
+        # For Python3 we decode binary strings as Unicode for compatibility
+        # with Python2
+        nvim = nvim.with_hook(DecodeHook())
 
     from .gtk_ui import GtkUI
     ui = GtkUI()

--- a/neovim/ui/cli.py
+++ b/neovim/ui/cli.py
@@ -8,6 +8,7 @@ from .. import attach
 from ..api import DecodeHook
 from ..compat import IS_PYTHON3
 
+
 @click.command(context_settings=dict(allow_extra_args=True))
 @click.option('--prog')
 @click.option('--notify', '-n', default=False, is_flag=True)


### PR DESCRIPTION
This is a simple fix to make the CLI work with python3. I took the code from one of the tests. It fixes #145.