### PR TITLE
lint: ignore E731 "do not assign a lambda expression"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [flake8]
-ignore = D211
+ignore = D211,E731


### PR DESCRIPTION
Alternatively we could change the code, but I think the code looks good as it is.