### PR TITLE
Don't use BaseException.message @equalsraf #152

### DIFF
--- a/neovim/msgpack_rpc/event_loop/asyncio.py
+++ b/neovim/msgpack_rpc/event_loop/asyncio.py
@@ -44,7 +44,7 @@ class AsyncioEventLoop(BaseEventLoop, asyncio.Protocol,
 
     def connection_lost(self, exc):
         """Used to signal `asyncio.Protocol` of a lost connection."""
-        self._on_error(exc.message if exc else 'EOF')
+        self._on_error(exc.args[0] if exc else 'EOF')
 
     def data_received(self, data):
         """Used to signal `asyncio.Protocol` of incoming data."""
@@ -55,7 +55,7 @@ class AsyncioEventLoop(BaseEventLoop, asyncio.Protocol,
 
     def pipe_connection_lost(self, fd, exc):
         """Used to signal `asyncio.SubprocessProtocol` of a lost connection."""
-        self._on_error(exc.message if exc else 'EOF')
+        self._on_error(exc.args[0] if exc else 'EOF')
 
     def pipe_data_received(self, fd, data):
         """Used to signal `asyncio.SubprocessProtocol` of incoming data."""


### PR DESCRIPTION
This patch helps show the underlying error in [#152](https://github.com/neovim/python-client/issues/152)

BaseException.message was only available in Python 2.5:
https://www.python.org/dev/peps/pep-0352/#retracted-ideas

This was patch was proposed in neovim/neovim #4253 by @equalsraf :
https://github.com/neovim/neovim/issues/4253#issuecomment-184437483

Without the change calling BaseException.message hides any errors behind an AttributeError:
AttributeError: 'OSError' object has no attribute 'message'