### PR TITLE
better handling of exceptions in async contexts

### DIFF
--- a/neovim/__init__.py
+++ b/neovim/__init__.py
@@ -16,7 +16,7 @@ from .plugin import (Host, autocmd, command, encoding, function, plugin,
 __all__ = ('tcp_session', 'socket_session', 'stdio_session', 'child_session',
            'start_host', 'autocmd', 'command', 'encoding', 'function',
            'plugin', 'rpc_export', 'Host', 'DecodeHook', 'Nvim',
-           'SessionHook', 'shutdown_hook', 'attach')
+           'SessionHook', 'shutdown_hook', 'attach', 'setup_logging')
 
 
 def start_host(session=None):
@@ -43,23 +43,8 @@ def start_host(session=None):
     if not plugins:
         sys.exit('must specify at least one plugin as argument')
 
-    logger = logging.getLogger(__name__)
-    if 'NVIM_PYTHON_LOG_FILE' in os.environ:
-        logfile = (os.environ['NVIM_PYTHON_LOG_FILE'].strip() +
-                   '_' + str(os.getpid()))
-        handler = logging.FileHandler(logfile, 'w')
-        handler.formatter = logging.Formatter(
-            '%(asctime)s [%(levelname)s @ '
-            '%(filename)s:%(funcName)s:%(lineno)s] %(process)s - %(message)s')
-        logging.root.addHandler(handler)
-        level = logging.INFO
-        if 'NVIM_PYTHON_LOG_LEVEL' in os.environ:
-            l = getattr(logging,
-                        os.environ['NVIM_PYTHON_LOG_LEVEL'].strip(),
-                        level)
-            if isinstance(l, int):
-                level = l
-        logger.setLevel(level)
+    setup_logging()
+
     if not session:
         session = stdio_session()
     host = Host(Nvim.from_session(session))
@@ -93,6 +78,27 @@ def attach(session_type, address=None, port=None, path=None, argv=None):
         raise Exception('Unknown session type "%s"' % session_type)
 
     return Nvim.from_session(session)
+
+
+def setup_logging():
+    """Setup logging according to environment variables."""
+    logger = logging.getLogger(__name__)
+    if 'NVIM_PYTHON_LOG_FILE' in os.environ:
+        logfile = (os.environ['NVIM_PYTHON_LOG_FILE'].strip() +
+                   '_' + str(os.getpid()))
+        handler = logging.FileHandler(logfile, 'w')
+        handler.formatter = logging.Formatter(
+            '%(asctime)s [%(levelname)s @ '
+            '%(filename)s:%(funcName)s:%(lineno)s] %(process)s - %(message)s')
+        logging.root.addHandler(handler)
+        level = logging.INFO
+        if 'NVIM_PYTHON_LOG_LEVEL' in os.environ:
+            l = getattr(logging,
+                        os.environ['NVIM_PYTHON_LOG_LEVEL'].strip(),
+                        level)
+            if isinstance(l, int):
+                level = l
+        logger.setLevel(level)
 
 
 # Required for python 2.6

--- a/neovim/msgpack_rpc/session.py
+++ b/neovim/msgpack_rpc/session.py
@@ -31,7 +31,11 @@ class Session(object):
     def threadsafe_call(self, fn, *args, **kwargs):
         """Wrapper around `AsyncSession.threadsafe_call`."""
         def handler():
-            fn(*args, **kwargs)
+            try:
+                fn(*args, **kwargs)
+            except Exception:
+                warn("error caught while excecuting async callback\n%s\n",
+                     format_exc())
 
         def greenlet_wrapper():
             gr = greenlet.greenlet(handler)
@@ -197,6 +201,7 @@ class Session(object):
             except Exception:
                 warn("error caught while processing notification '%s %s': %s",
                      name, args, format_exc())
+
             debug('greenlet %s is now dying...', gr)
 
         gr = greenlet.greenlet(handler)

--- a/neovim/plugin/host.py
+++ b/neovim/plugin/host.py
@@ -6,9 +6,10 @@ import logging
 import os
 import os.path
 
+from traceback import format_exc
+
 from ..api import DecodeHook
 from ..compat import IS_PYTHON3, find_module
-
 
 __all__ = ('Host')
 
@@ -76,7 +77,13 @@ class Host(object):
             return
 
         debug('calling notification handler for "%s", args: "%s"', name, args)
-        handler(*args)
+        try:
+            handler(*args)
+        except Exception as err:
+            msg = ("error caught in async handler '{} {}':\n{!r}\n{}"
+                   .format(name, args, err, format_exc(5)))
+            self.nvim.err_write(msg, async=True)
+            raise
 
     def _load(self, plugins):
         for path in plugins:

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -6,6 +6,7 @@ import neovim
 
 from nose.tools import eq_ as eq
 
+neovim.setup_logging()
 
 if 'NVIM_CHILD_ARGV' in os.environ:
     vim = neovim.attach('child', argv=json.loads(os.environ['NVIM_CHILD_ARGV']))
@@ -16,7 +17,6 @@ if sys.version_info >= (3, 0):
     # For Python3 we decode binary strings as Unicode for compatibility
     # with Python2
     vim = vim.with_hook(neovim.DecodeHook())
-
 
 cleanup_func = ''':function BeforeEachTest()
   set all&

--- a/test/test_concurrency.py
+++ b/test/test_concurrency.py
@@ -9,3 +9,11 @@ def test_interrupt_from_another_thread():
     timer = Timer(0.5, lambda: session.threadsafe_call(lambda: session.stop()))
     timer.start()
     eq(vim.session.next_message(), None)
+
+
+@with_setup(setup=cleanup)
+def test_exception_in_threadsafe_call():
+    # an exception in a threadsafe_call shouldn't crash the entire host
+    vim.session.threadsafe_call(lambda: [vim.eval("3"), undefined_variable])
+    vim.session.threadsafe_call(lambda: vim.session.stop())
+    vim.session.run(None, None)


### PR DESCRIPTION
This oneliner crashes the python client:
`py vim.session.threadsafe_call(lambda: [vim.eval("3"),undefined_variable])`
yes the `vim.eval("3")` is needed.

Print exceptions arising from async plugin handler, as already is done for sync ones.

Define `nvim.threadsafe_call` a wrapper around `nvim.session.threadsafe_call`) that prints uncaught exceptions in the async call, as well as the context the call came from. Also I don't think we should recommend plugins to call methods on `nvim.session` if they can avoid it, it's better to put all exported methods, including `threadsafe_call` on the api objects.

Docs are missing, so WIP.