### PR TITLE
be more verbose about import errors

### DIFF
--- a/neovim/__init__.py
+++ b/neovim/__init__.py
@@ -7,8 +7,8 @@ import os
 import sys
 
 from .api import DecodeHook, Nvim, SessionHook
-from .msgpack_rpc import (child_session, socket_session, stdio_session,
-                          tcp_session)
+from .msgpack_rpc import (ErrorResponse, child_session, socket_session,
+                          stdio_session, tcp_session)
 from .plugin import (Host, autocmd, command, encoding, function, plugin,
                      rpc_export, shutdown_hook)
 
@@ -16,7 +16,8 @@ from .plugin import (Host, autocmd, command, encoding, function, plugin,
 __all__ = ('tcp_session', 'socket_session', 'stdio_session', 'child_session',
            'start_host', 'autocmd', 'command', 'encoding', 'function',
            'plugin', 'rpc_export', 'Host', 'DecodeHook', 'Nvim',
-           'SessionHook', 'shutdown_hook', 'attach', 'setup_logging')
+           'SessionHook', 'shutdown_hook', 'attach', 'setup_logging',
+           'ErrorResponse')
 
 
 def start_host(session=None):

--- a/neovim/msgpack_rpc/__init__.py
+++ b/neovim/msgpack_rpc/__init__.py
@@ -7,10 +7,11 @@ code here should work with other msgpack-rpc servers.
 from .async_session import AsyncSession
 from .event_loop import EventLoop
 from .msgpack_stream import MsgpackStream
-from .session import Session
+from .session import ErrorResponse, Session
 
 
-__all__ = ('tcp_session', 'socket_session', 'stdio_session', 'child_session')
+__all__ = ('tcp_session', 'socket_session', 'stdio_session', 'child_session',
+           'ErrorResponse')
 
 
 def session(transport_type='stdio', *args, **kwargs):

--- a/neovim/msgpack_rpc/session.py
+++ b/neovim/msgpack_rpc/session.py
@@ -182,6 +182,10 @@ class Session(object):
                 debug('greenlet %s finished executing, ' +
                       'sending %s as response', gr, rv)
                 response.send(rv)
+            except ErrorResponse as err:
+                warn("error response from request '%s %s': %s", name,
+                     args, format_exc())
+                response.send(err.args[0], error=True)
             except Exception as err:
                 warn("error caught while processing request '%s %s': %s", name,
                      args, format_exc())
@@ -207,3 +211,15 @@ class Session(object):
         gr = greenlet.greenlet(handler)
         debug('received rpc notification, greenlet %s will handle it', gr)
         gr.switch()
+
+
+class ErrorResponse(BaseException):
+
+    """Raise this in a request handler to respond with a given error message.
+
+    Unlike when other exceptions are caught, this gives full control off the
+    error response sent. When "ErrorResponse(msg)" is caught "msg" will be
+    sent verbatim as the error response.No traceback will be appended.
+    """
+
+    pass


### PR DESCRIPTION
On `:UpdateRemotePlugins`: if a plugin fails to load due to import error, tell the user/developer about it.

If a request handler is missing due to import error (the plugin file or dependency thereof was changed since the last URP) give the import error instead of useless traceback of the host/msgpack implementation (or even worse: no error at all for async notifications)