### PR TITLE
Make the host find package dirs in "rplugin/python3"

### DIFF
--- a/neovim/__init__.py
+++ b/neovim/__init__.py
@@ -39,6 +39,18 @@ def start_host(session=None):
         _, ext = os.path.splitext(arg)
         if ext == '.py':
             plugins.append(arg)
+        elif os.path.isdir(arg):
+            init = os.path.join(arg, '__init__.py')
+            if os.path.isfile(init):
+                plugins.append(arg)
+
+    # This is a special case to support the old workaround of
+    # adding an empty .py file to make a package directory
+    # visible, and it should be removed soon.
+    for path in list(plugins):
+        dup = path + ".py"
+        if os.path.isdir(path) and dup in plugins:
+            plugins.remove(dup)
 
     if not plugins:
         sys.exit('must specify at least one plugin as argument')

--- a/neovim/plugin/host.py
+++ b/neovim/plugin/host.py
@@ -183,7 +183,7 @@ class Host(object):
     def _on_specs_request(self, path):
         if IS_PYTHON3 and isinstance(path, bytes):
             path = path.decode(self._nvim_encoding)
-        return self._specs.get(path, [])
+        return self._specs.get(path, 0)
 
     def _decodehook_for(self, encoding):
         if IS_PYTHON3 and encoding is None:


### PR DESCRIPTION
Currently when having a package in `rplugin/python3`:

    ~/.config/nvim/bundle/deoplete.nvim/rplugin/python3/deoplete/

one needs to have a empty marker file

    ~/.config/nvim/bundle/deoplete.nvim/rplugin/python3/deoplete.py

This patch removes that need. It also has a workaround to support the existing workaround, which should be removed eventually.

Needs an update to neovim/neovim as well