### PR TITLE
remove decodehook

### DIFF
--- a/neovim/__init__.py
+++ b/neovim/__init__.py
@@ -6,16 +6,16 @@ import logging
 import os
 import sys
 
-from .api import DecodeHook, Nvim
+from .api import Nvim
 from .msgpack_rpc import (ErrorResponse, child_session, socket_session,
                           stdio_session, tcp_session)
-from .plugin import (Host, autocmd, command, encoding, function, plugin,
-                     rpc_export, shutdown_hook)
+from .plugin import (Host, autocmd, command, decode, encoding, function,
+                     plugin, rpc_export, shutdown_hook)
 
 
 __all__ = ('tcp_session', 'socket_session', 'stdio_session', 'child_session',
-           'start_host', 'autocmd', 'command', 'encoding', 'function',
-           'plugin', 'rpc_export', 'Host', 'DecodeHook', 'Nvim',
+           'start_host', 'autocmd', 'command', 'encoding', 'decode',
+           'function', 'plugin', 'rpc_export', 'Host', 'Nvim',
            'shutdown_hook', 'attach', 'setup_logging', 'ErrorResponse')
 
 

--- a/neovim/__init__.py
+++ b/neovim/__init__.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 from .api import Nvim
+from .compat import IS_PYTHON3
 from .msgpack_rpc import (ErrorResponse, child_session, socket_session,
                           stdio_session, tcp_session)
 from .plugin import (Host, autocmd, command, decode, encoding, function,
@@ -63,7 +64,8 @@ def start_host(session=None):
     host.start(plugins)
 
 
-def attach(session_type, address=None, port=None, path=None, argv=None):
+def attach(session_type, address=None, port=None,
+           path=None, argv=None, decode=None):
     """Provide a nicer interface to create python api sessions.
 
     Previous machinery to create python api sessions is still there. This only
@@ -89,7 +91,10 @@ def attach(session_type, address=None, port=None, path=None, argv=None):
     if not session:
         raise Exception('Unknown session type "%s"' % session_type)
 
-    return Nvim.from_session(session)
+    if decode is None:
+        decode = IS_PYTHON3
+
+    return Nvim.from_session(session).with_decode(decode)
 
 
 def setup_logging():

--- a/neovim/api/__init__.py
+++ b/neovim/api/__init__.py
@@ -5,11 +5,11 @@ instances.
 """
 
 from .buffer import Buffer
-from .common import DecodeHook
+from .common import decode_if_bytes, walk
 from .nvim import Nvim, NvimError
 from .tabpage import Tabpage
 from .window import Window
 
 
 __all__ = ('Nvim', 'Buffer', 'Window', 'Tabpage', 'NvimError',
-           'DecodeHook')
+           'decode_if_bytes', 'walk')

--- a/neovim/api/common.py
+++ b/neovim/api/common.py
@@ -153,38 +153,20 @@ def _identity(obj, session, method, kind):
     return obj
 
 
-class DecodeHook(object):
-
-    """SessionHook subclass that decodes utf-8 strings coming from Nvim.
-
-    This class is useful for python3, where strings are now unicode by
-    default(byte strings need to be prefixed with "b").
-    """
-
-    def __init__(self, encoding='utf-8', encoding_errors='strict'):
-        """Initialize with encoding and encoding errors policy."""
-        self.encoding = encoding
-        self.encoding_errors = encoding_errors
-
-    def decode_if_bytes(self, obj):
-        """Decode obj if it is bytes."""
-        if isinstance(obj, bytes):
-            return obj.decode(self.encoding, errors=self.encoding_errors)
-        return obj
-
-    def walk(self, obj):
-        """Decode bytes found in obj (any msgpack object).
-
-        Uses encoding and policy specified in constructor.
-        """
-        return walk(self.decode_if_bytes, obj)
+def decode_if_bytes(obj, mode=True):
+    """Decode obj if it is bytes."""
+    if mode is True:
+        mode = "strict"
+    if isinstance(obj, bytes):
+        return obj.decode("utf-8", errors=mode)
+    return obj
 
 
-def walk(fn, obj, *args):
+def walk(fn, obj, *args, **kwargs):
     """Recursively walk an object graph applying `fn`/`args` to objects."""
     if type(obj) in [list, tuple]:
         return list(walk(fn, o, *args) for o in obj)
     if type(obj) is dict:
         return dict((walk(fn, k, *args), walk(fn, v, *args)) for k, v in
                     obj.items())
-    return fn(obj, *args)
+    return fn(obj, *args, **kwargs)

--- a/neovim/msgpack_rpc/session.py
+++ b/neovim/msgpack_rpc/session.py
@@ -76,10 +76,14 @@ class Session(object):
         sent instead. This will never block, and the return value or error is
         ignored.
         """
-        async = kwargs.get('async', False)
+        async = kwargs.pop('async', False)
         if async:
             self._async_session.notify(method, args)
             return
+
+        if kwargs:
+            raise ValueError("request got unsupported keyword argument(s): {0}"
+                             .format(', '.join(kwargs.keys())))
 
         if self._is_running:
             v = self._yielding_request(method, args)

--- a/neovim/plugin/__init__.py
+++ b/neovim/plugin/__init__.py
@@ -1,9 +1,9 @@
 """Nvim plugin/host subpackage."""
 
-from .decorators import (autocmd, command, encoding, function, plugin,
-                         rpc_export, shutdown_hook)
+from .decorators import (autocmd, command, decode, encoding, function,
+                         plugin, rpc_export, shutdown_hook)
 from .host import Host
 
 
 __all__ = ('Host', 'plugin', 'rpc_export', 'command', 'autocmd',
-           'function', 'encoding', 'shutdown_hook')
+           'function', 'encoding', 'decode', 'shutdown_hook')

--- a/neovim/plugin/decorators.py
+++ b/neovim/plugin/decorators.py
@@ -8,7 +8,7 @@ from ..compat import IS_PYTHON3
 logger = logging.getLogger(__name__)
 debug, info, warn = (logger.debug, logger.info, logger.warning,)
 __all__ = ('plugin', 'rpc_export', 'command', 'autocmd', 'function',
-           'encoding', 'shutdown_hook')
+           'encoding', 'decode', 'shutdown_hook')
 
 
 def plugin(cls):
@@ -141,9 +141,20 @@ def shutdown_hook(f):
     return f
 
 
-def encoding(encoding=True):
+def decode(mode='strict'):
     """Configure automatic encoding/decoding of strings."""
     def dec(f):
-        f._nvim_encoding = encoding
+        f._nvim_decode = mode
+        return f
+    return dec
+
+
+def encoding(encoding=True):
+    """DEPRECATED: use neovim.decode()."""
+    if isinstance(encoding, str):
+        encoding = True
+
+    def dec(f):
+        f._nvim_decode = encoding
         return f
     return dec

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -18,11 +18,6 @@ if child_argv is not None:
 else:
     vim = neovim.attach('socket', path=listen_address)
 
-if sys.version_info >= (3, 0):
-    # For Python3 we decode binary strings as Unicode for compatibility
-    # with Python2
-    vim = vim.with_decode()
-
 cleanup_func = ''':function BeforeEachTest()
   set all&
   redir => groups

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -21,7 +21,7 @@ else:
 if sys.version_info >= (3, 0):
     # For Python3 we decode binary strings as Unicode for compatibility
     # with Python2
-    vim = vim.with_decodehook(neovim.DecodeHook())
+    vim = vim.with_decode()
 
 cleanup_func = ''':function BeforeEachTest()
   set all&


### PR DESCRIPTION
While doing breaking changes ( #179 ) ...

Per decision, rplugins do not need support `encoding != utf-8`. (But it should not be too hard to add back if we really want this.) But setting the encoding (and not just an on/off switch) per rplugin definitely makes no sense.

Allows to turn on/off decoding per request, ref #184 .