### PR TITLE
Fix `bang` and `register` command modifier

### DIFF
--- a/neovim/plugin/decorators.py
+++ b/neovim/plugin/decorators.py
@@ -59,10 +59,10 @@ def command(name, nargs=0, complete=None, range=None, count=None, bang=False,
             opts['count'] = count
 
         if bang:
-            opts['bang'] = True
+            opts['bang'] = ''
 
         if register:
-            opts['register'] = True
+            opts['register'] = ''
 
         if nargs:
             opts['nargs'] = nargs


### PR DESCRIPTION
Defining a command with `bang=True` leads to a .init.vim-rplugin~ file which Neovim can't read.
I'm not sure if this belongs here or if it is a Neovim bug, but it's quite easy to fix. 