### PR TITLE
Fix failing tests on Windows.

### DIFF
--- a/test/test_vim.py
+++ b/test/test_vim.py
@@ -21,7 +21,8 @@ def test_command():
     vim.command('normal itesting\npython\napi')
     vim.command('w')
     ok(os.path.isfile(fname))
-    eq(open(fname).read(), 'testing\npython\napi\n')
+    with open(fname) as f:
+      eq(f.read(), 'testing\npython\napi\n')
     os.unlink(fname)
 
 
@@ -63,8 +64,10 @@ def test_strwidth():
 @with_setup(setup=cleanup)
 def test_chdir():
     pwd = vim.eval('getcwd()')
+    root = os.path.abspath(os.sep)
+    # We can chdir to '/' on Windows, but then the pwd will be the root drive
     vim.chdir('/')
-    eq(vim.eval('getcwd()'), '/')
+    eq(vim.eval('getcwd()'), root)
     vim.chdir(pwd)
     eq(vim.eval('getcwd()'), pwd)
 


### PR DESCRIPTION
Test "test_vim.test_command" was failing because of the call to
os.unlink(..), as the file was still open in vim. Adding a conditional
to execute the call only if we are not running under Windows was the
most straight-forward "fix".

Test "test_vim.test_chdir" was failing for two reasons. Firstly because
of missing Windows-specific handling of path names in
find_file_in_path_option in file_search.c in Neovim core. Secondly
because although one can indeed `:cd /` on Windows (or at least, should
be able to), a corresponding call to `:pwd` will echo the root drive
of the current working directory of Neovim.

test_chdir should work now that neovim/neovim#4711 was merged.
