### PR TITLE
vim.buffers is a map not a list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ bridge](http://vimdoc.sourceforge.net/htmldoc/if_pyth.html#python-vim)):
 # Create a python API session attached to unix domain socket created above:
 >>> nvim = attach('socket', path='/tmp/nvim')
 # Now do some work. 
->>> buffer = nvim.buffers[0] # Get the first buffer
+>>> buffer = nvim.current.buffer # Get the current buffer
 >>> buffer[0] = 'replace first line'
 >>> buffer[:] = ['replace whole buffer']
 >>> nvim.command('vsplit')

--- a/neovim/api/buffer.py
+++ b/neovim/api/buffer.py
@@ -1,4 +1,4 @@
-"""API for working with Nvim buffers."""
+"""API for working with a Nvim Buffer."""
 from .common import Remote
 from ..compat import IS_PYTHON3
 

--- a/neovim/api/common.py
+++ b/neovim/api/common.py
@@ -113,9 +113,9 @@ class RemoteSequence(object):
     sequences(of lines, buffers, windows and tabpages) with an API that
     is similar to the one provided by the python-vim interface.
 
-    For example, the 'buffers' property of the `Nvim class is a RemoteSequence
-    sequence instance, and the expression `nvim.buffers[0]` is translated to
-    session.request('vim_get_buffers')[0].
+    For example, the 'windows' property of the `Nvim` class is a RemoteSequence
+    sequence instance, and the expression `nvim.windows[0]` is translated to
+    session.request('vim_get_windows')[0].
 
     It can also receive an optional self_obj that will be passed as first
     argument of the request. For example, `tabpage.windows[0]` is translated

--- a/test/test_vim.py
+++ b/test/test_vim.py
@@ -92,13 +92,29 @@ def test_options():
 
 @with_setup(setup=cleanup)
 def test_buffers():
+    buffers = []
+
+    # Number of elements
     eq(len(vim.buffers), 1)
-    eq(vim.buffers[0], vim.current.buffer)
+
+    # Indexing (by buffer number)
+    eq(vim.buffers[vim.current.buffer.number], vim.current.buffer)
+
+    buffers.append(vim.current.buffer)
     vim.command('new')
     eq(len(vim.buffers), 2)
-    eq(vim.buffers[1], vim.current.buffer)
-    vim.current.buffer = vim.buffers[0]
-    eq(vim.buffers[0], vim.current.buffer)
+    buffers.append(vim.current.buffer)
+    eq(vim.buffers[vim.current.buffer.number], vim.current.buffer)
+    vim.current.buffer = buffers[0]
+    eq(vim.buffers[vim.current.buffer.number], buffers[0])
+
+    # Membership test
+    ok(buffers[0] in vim.buffers)
+    ok(buffers[1] in vim.buffers)
+    ok({} not in vim.buffers)
+
+    # Iteration
+    eq(buffers, list(vim.buffers))
 
 
 @with_setup(setup=cleanup)


### PR DESCRIPTION
`python-buffers` describes `vim.buffers` as a mapping object. `python-buffer`
documents that `b.number` where `b` is a Buffer object can be used as a
`python-buffers` key. I.e. `b == vim.buffers[b.number]` should be true if `b`
is a valid buffer object.

`nvim.py` was implementing `vim.buffers` as a `RemoteSequence` which doesn't
provide the aforementioned properties. This change implements it as a
`RemoteSequenceAsMap` object instead. The latter is a new class that
allows a sequence returned via a single msgpack-rpc call to be exposed
to Python as a map.