### PR TITLE
nvim: show errors in handler on stderr when used as client

### DIFF
--- a/neovim/api/buffer.py
+++ b/neovim/api/buffer.py
@@ -125,7 +125,7 @@ class Buffer(Remote):
                             line, col_start, col_end, async=async)
 
     def clear_highlight(self, src_id, line_start=0, line_end=-1, async=True):
-        """clear highlights from the buffer."""
+        """Clear highlights from the buffer."""
         self.request('buffer_clear_highlight', src_id,
                      line_start, line_end, async=async)
 

--- a/neovim/plugin/host.py
+++ b/neovim/plugin/host.py
@@ -77,7 +77,6 @@ class Host(object):
                 msg = ("error caught in async handler '{} {}'\n{}\n"
                        .format(name, args, format_exc_skip(1, 5)))
                 self._on_async_err(msg + "\n")
-                raise
 
     def _on_request(self, name, args):
         """Handle a msgpack-rpc request."""


### PR DESCRIPTION
fixes #216. A modified test case to cover both cases:

```
import sys
import os
from neovim import attach

def setup_cb():
    nvim.command('call rpcnotify({}, "foo")'.format(nvim.channel_id))
    nvim.call('rpcrequest', nvim.channel_id, "bar", "xx", async=True)


def notification_cb(msg, _args):
    num -= 1

def request_cb(name, args):
    FAIL


nvim = attach('child', argv=['nvim', '-u', 'NONE', '--embed'])
nvim.run_loop(request_cb, notification_cb, setup_cb)
```

This should not affect plugins running inside vim, as the plugin host already catches `Exception`:s and displays the plugin traceback appropriately.