### PR TITLE
asyncio: use stderr fd constant

### DIFF
--- a/neovim/msgpack_rpc/event_loop/asyncio.py
+++ b/neovim/msgpack_rpc/event_loop/asyncio.py
@@ -59,7 +59,7 @@ class AsyncioEventLoop(BaseEventLoop, asyncio.Protocol,
 
     def pipe_data_received(self, fd, data):
         """Used to signal `asyncio.SubprocessProtocol` of incoming data."""
-        if fd == sys.stderr.fileno():
+        if fd == 2:  # stderr fd number
             self._on_stderr(data)
         elif self._on_data:
             self._on_data(data)


### PR DESCRIPTION
sys.stderr might be monkey-patched by other library like kivy (ref #218)  and not always
work. Also it gives the impression the stderr stream of the python process
is used which it isn't.