### PR TITLE
logging: use predictable log file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ You can run the plugin host in nvim with logging enabled to debug errors:
 NVIM_PYTHON_LOG_FILE=logfile NVIM_PYTHON_LOG_LEVEL=DEBUG nvim
 ```
 As more than one python host process might be started, the log filenames take
-the pattern `logfile_PID` where `PID` is the process id.
+the pattern `logfile_pyX_KIND` where `X` is the major python version (2 or 3)
+and `KIND` is either "rplugin" or "script" (for the `:python[3]`
+script interface).
 
 If the host cannot start at all, the error could be found in `~/.nvimlog` if
 `nvim` was compiled with logging.

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -6,7 +6,7 @@ import neovim
 
 from nose.tools import eq_ as eq
 
-neovim.setup_logging()
+neovim.setup_logging("test")
 
 child_argv = os.environ.get('NVIM_CHILD_ARGV')
 listen_address = os.environ.get('NVIM_LISTEN_ADDRESS')


### PR DESCRIPTION
Fixes #222 . Logs now have names as `{$NVIM_PYTHON_LOG_FILE}_py{X}_{NAME}` where X is 2 or 3 and NAME is either "rplugin" or "script" (or "test" when running nosetests with logging). ping @blueyed 