### PR TITLE
Fix/remove limit with format_exc_skip

### DIFF
--- a/neovim/api/nvim.py
+++ b/neovim/api/nvim.py
@@ -157,7 +157,7 @@ class Nvim(object):
                 result = request_cb(name, args)
             except Exception:
                 msg = ("error caught in request handler '{} {}'\n{}\n\n"
-                       .format(name, args, format_exc_skip(1, 5)))
+                       .format(name, args, format_exc_skip(1)))
                 self._err_cb(msg)
                 raise
             return walk(self._to_nvim, result)
@@ -169,7 +169,7 @@ class Nvim(object):
                 notification_cb(name, args)
             except Exception:
                 msg = ("error caught in notification handler '{} {}'\n{}\n\n"
-                       .format(name, args, format_exc_skip(1, 5)))
+                       .format(name, args, format_exc_skip(1)))
                 self._err_cb(msg)
                 raise
 
@@ -340,7 +340,7 @@ class Nvim(object):
             except Exception as err:
                 msg = ("error caught while executing async callback:\n"
                        "{0!r}\n{1}\n \nthe call was requested at\n{2}"
-                       .format(err, format_exc_skip(1, 5), call_point))
+                       .format(err, format_exc_skip(1), call_point))
                 self._err_cb(msg)
                 raise
         self._session.threadsafe_call(handler)

--- a/neovim/plugin/host.py
+++ b/neovim/plugin/host.py
@@ -71,11 +71,11 @@ class Host(object):
         except Exception:
             if sync:
                 msg = ("error caught in request handler '{} {}':\n{}"
-                       .format(name, args, format_exc_skip(1, 5)))
+                       .format(name, args, format_exc_skip(1)))
                 raise ErrorResponse(msg)
             else:
                 msg = ("error caught in async handler '{} {}'\n{}\n"
-                       .format(name, args, format_exc_skip(1, 5)))
+                       .format(name, args, format_exc_skip(1)))
                 self._on_async_err(msg + "\n")
 
     def _on_request(self, name, args):


### PR DESCRIPTION
This used limit=5 in several places, but this limits it to the first 5
frames, hiding the source of the exception!

While limit=-5 could be used instead, I think it is better to provide
the full traceback always.

Some example msg from manually raising an exception with deoplete-jedi:

```
error caught in async handler 'deoplete_on_event [{'next_input': 'in async handler \'{} {}\'\\n{}\\n"', 'event': '', 'position': [0, 77, 38, 0], 'bufvars': {}, 'max_menu_width': 101, 'vars':
 {'deoplete#ignore_sources': {'_': ['tmux-complete']}, 'deoplete#_keyword_patterns': {'_': '[a-zA-Z_]\\k*'}, 'deoplete#enable_debug': 1, 'deoplete#auto_refresh_delay': 50, 'deoplete#enable_p
rofile': 0, 'deoplete#_rank': {}, 'deoplete#auto_complete_delay': 200, 'deoplete#delimiters': ['/', '.', '::', ':', '#'], 'deoplete#auto_complete_start_length': 2, 'deoplete#member#prefix_pa
tterns': {}, 'deoplete#enable_ignore_case': 1, 'deoplete#_channel_id': 1, 'deoplete#sources': {}, 'deoplete#enable_camel_case': 0, 'deoplete#max_menu_width': 40, 'deoplete#keyword_patterns':
 {}, 'deoplete#enable_refresh_always': 0, 'deoplete#omni#functions': {}, 'deoplete#max_abbr_width': 80, 'deoplete#sources#jedi#show_docstring_sig': 0, 'deoplete#enable_smart_case': 1, 'deopl
ete#_omni_patterns': {'markdown': ['<', '<[^>]*\\s[[:alnum:]-]*'], 'xml': ['<', '<[^>]*\\s[[:alnum:]-]*'], 'mkd': ['<', '<[^>]*\\s[[:alnum:]-]*'], 'html': ['<', '<[^>]*\\s[[:alnum:]-]*'], 'x
html': ['<', '<[^>]*\\s[[:alnum:]-]*']}, 'deoplete#omni#input_patterns': {}, 'deoplete#enable_at_startup': 1, 'deoplete#_neovim_python_version': ['0.1.10'], 'deoplete#_context': {}, 'deoplet
e#max_list': 100, 'deoplete#disable_auto_complete': 0, 'deoplete#sources#jedi#show_docstring': 1, 'deoplete#omni_patterns': {}}, 'max_abbr_width': 101, 'rpc': 'deoplete_on_event', 'omni__omn
ifunc': 'jedi#completions', 'delay': 200, 'filetype': 'python', 'bufname': 'neovim/plugin/host.py', 'camelcase': 0, 'filetypes': ['python'], 'bufnr': 3, 'runtimepath': '…', 'smartcase': 1, 'sources': [], 'keyword_patterns': '[a-zA-Z_][a-zA-Z@0-9_À-ÿ]*', 'cwd': '…/Vcs/neovim-python-client', '
start_complete': '\udc80\udcfdR(deoplete_start_complete)', 'complete_str': '', 'ignorecase': 1, 'changedtick': 2, 'custom': {'jedi': {'debug_enabled': 1}, '_': {}}, 'input': '               
 msg = ("error caught ', 'dict__dictionary': '', 'encoding': 'utf-8'}]'
Traceback (most recent call last):
  File "/home/user/.vim/neobundles/deoplete/rplugin/python3/deoplete/__init__.py", line 62, in on_event
    self.__deoplete.on_event(context)
  File "/home/user/.vim/neobundles/deoplete/rplugin/python3/deoplete/deoplete.py", line 377, in on_event
    for source_name, source in self.itersource(context):
  File "/home/user/.vim/neobundles/deoplete/rplugin/python3/deoplete/deoplete.py", line 196, in itersource
    source.on_init(context)
  File "/home/user/.vim/neobundles/deoplete-jedi/rplugin/python3/deoplete/sources/deoplete_jedi.py", line 63, in on_init
    self.debug_enabled, self.python_path)
  File "/home/user/.vim/neobundles/deoplete-jedi/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py", line 77, in start
    show_docstring, debug, python_path)
  File "/home/user/.vim/neobundles/deoplete-jedi/rplugin/python3/deoplete/sources/deoplete_jedi/worker.py", line 24, in __init__
    python_path)
  File "/home/user/.vim/neobundles/deoplete-jedi/rplugin/python3/deoplete/sources/deoplete_jedi/server.py", line 502, in __init__
    self.restart()
  File "/home/user/.vim/neobundles/deoplete-jedi/rplugin/python3/deoplete/sources/deoplete_jedi/server.py", line 518, in restart
    self.version = stream_read(self._server.stdout)
  File "/home/user/.vim/neobundles/deoplete-jedi/rplugin/python3/deoplete/sources/deoplete_jedi/server.py", line 83, in stream_read
    raise StreamEmpty
deoplete_jedi.server.StreamEmpty
```

Without this patch, it would only display the first 5 frames, which was really confusing.

Please note that including args here is quite verbose (although I've removed the `'runtimepath'` already).
Those should be limited maybe instead?!
