### PR TITLE
[RFC] update to api level 1

### DIFF
--- a/neovim/__init__.py
+++ b/neovim/__init__.py
@@ -12,12 +12,16 @@ from .msgpack_rpc import (ErrorResponse, child_session, socket_session,
                           stdio_session, tcp_session)
 from .plugin import (Host, autocmd, command, decode, encoding, function,
                      plugin, rpc_export, shutdown_hook)
+from .util import Version
 
 
 __all__ = ('tcp_session', 'socket_session', 'stdio_session', 'child_session',
            'start_host', 'autocmd', 'command', 'encoding', 'decode',
-           'function', 'plugin', 'rpc_export', 'Host', 'Nvim',
+           'function', 'plugin', 'rpc_export', 'Host', 'Nvim', 'VERSION',
            'shutdown_hook', 'attach', 'setup_logging', 'ErrorResponse')
+
+
+VERSION = Version(major=0, minor=1, patch=11, prerelease="dev")
 
 
 def start_host(session=None):
@@ -64,7 +68,14 @@ def start_host(session=None):
 
     if not session:
         session = stdio_session()
-    host = Host(Nvim.from_session(session))
+    nvim = Nvim.from_session(session)
+
+    if nvim.version.api_level < 1:
+        sys.stderr.write("This version of the neovim python package "
+                         "requires nvim 0.1.6 or later")
+        sys.exit(1)
+
+    host = Host(nvim)
     host.start(plugins)
 
 

--- a/neovim/api/buffer.py
+++ b/neovim/api/buffer.py
@@ -24,7 +24,7 @@ class Buffer(Remote):
 
     """A remote Nvim buffer."""
 
-    _api_prefix = "buffer_"
+    _api_prefix = "nvim_buf_"
 
     def __len__(self):
         """Return the number of lines contained in a Buffer."""
@@ -42,10 +42,10 @@ class Buffer(Remote):
         """
         if not isinstance(idx, slice):
             i = adjust_index(idx)
-            return self.request('buffer_get_lines', i, i + 1, True)[0]
+            return self.request('nvim_buf_get_lines', i, i + 1, True)[0]
         start = adjust_index(idx.start, 0)
         end = adjust_index(idx.stop, -1)
-        return self.request('buffer_get_lines', start, end, False)
+        return self.request('nvim_buf_get_lines', start, end, False)
 
     def __setitem__(self, idx, item):
         """Replace a buffer line or slice by integer index.
@@ -58,7 +58,7 @@ class Buffer(Remote):
         if not isinstance(idx, slice):
             i = adjust_index(idx)
             lines = [item] if item is not None else []
-            return self.request('buffer_set_lines', i, i + 1, True, lines)
+            return self.request('nvim_buf_set_lines', i, i + 1, True, lines)
         lines = item if item is not None else []
         start = adjust_index(idx.start, 0)
         end = adjust_index(idx.stop, -1)
@@ -87,11 +87,11 @@ class Buffer(Remote):
         """Append a string or list of lines to the buffer."""
         if isinstance(lines, (basestring, bytes)):
             lines = [lines]
-        return self.request('buffer_set_lines', index, index, True, lines)
+        return self.request('nvim_buf_set_lines', index, index, True, lines)
 
     def mark(self, name):
         """Return (row, col) tuple for a named mark."""
-        return self.request('buffer_get_mark', name)
+        return self.request('nvim_buf_get_mark', name)
 
     def range(self, start, end):
         """Return a `Range` object, which represents part of the Buffer."""
@@ -102,33 +102,33 @@ class Buffer(Remote):
         """Add a highlight to the buffer."""
         if async is None:
             async = (src_id != 0)
-        return self.request('buffer_add_highlight', src_id, hl_group,
+        return self.request('nvim_buf_add_highlight', src_id, hl_group,
                             line, col_start, col_end, async=async)
 
     def clear_highlight(self, src_id, line_start=0, line_end=-1, async=True):
         """Clear highlights from the buffer."""
-        self.request('buffer_clear_highlight', src_id,
+        self.request('nvim_buf_clear_highlight', src_id,
                      line_start, line_end, async=async)
 
     @property
     def name(self):
         """Get the buffer name."""
-        return self.request('buffer_get_name')
+        return self.request('nvim_buf_get_name')
 
     @name.setter
     def name(self, value):
         """Set the buffer name. BufFilePre/BufFilePost are triggered."""
-        return self.request('buffer_set_name', value)
+        return self.request('nvim_buf_set_name', value)
 
     @property
     def valid(self):
         """Return True if the buffer still exists."""
-        return self.request('buffer_is_valid')
+        return self.request('nvim_buf_is_valid')
 
     @property
     def number(self):
         """Get the buffer number."""
-        return self.request('buffer_get_number')
+        return self.request('nvim_buf_get_number')
 
 
 class Range(object):

--- a/neovim/api/nvim.py
+++ b/neovim/api/nvim.py
@@ -13,7 +13,7 @@ from .common import (Remote, RemoteApi, RemoteMap, RemoteSequence,
 from .tabpage import Tabpage
 from .window import Window
 from ..compat import IS_PYTHON3
-from ..util import format_exc_skip
+from ..util import Version, format_exc_skip
 
 __all__ = ('Nvim')
 
@@ -74,6 +74,8 @@ class Nvim(object):
         self._session = session
         self.channel_id = channel_id
         self.metadata = metadata
+        version = metadata.get("version", {"api_level": 0})
+        self.version = Version(**version)
         self.types = types
         self.api = RemoteApi(self, 'nvim_')
         self.vars = RemoteMap(self, 'nvim_get_var', 'nvim_set_var')

--- a/neovim/api/nvim.py
+++ b/neovim/api/nvim.py
@@ -75,13 +75,13 @@ class Nvim(object):
         self.channel_id = channel_id
         self.metadata = metadata
         self.types = types
-        self.api = RemoteApi(self, 'vim_')
-        self.vars = RemoteMap(self, 'vim_get_var', 'vim_set_var')
+        self.api = RemoteApi(self, 'nvim_')
+        self.vars = RemoteMap(self, 'nvim_get_var', 'nvim_set_var')
         self.vvars = RemoteMap(self, 'vim_get_vvar', None)
-        self.options = RemoteMap(self, 'vim_get_option', 'vim_set_option')
+        self.options = RemoteMap(self, 'nvim_get_option', 'nvim_set_option')
         self.buffers = Buffers(self)
-        self.windows = RemoteSequence(self, 'vim_get_windows')
-        self.tabpages = RemoteSequence(self, 'vim_get_tabpages')
+        self.windows = RemoteSequence(self, 'nvim_list_wins')
+        self.tabpages = RemoteSequence(self, 'nvim_list_tabpages')
         self.current = Current(self)
         self.session = CompatibilitySession(self)
         self.funcs = Funcs(self)
@@ -116,8 +116,8 @@ class Nvim(object):
 
         is equivalent to
 
-            vim.request('vim_err_write', 'ERROR\n', async=True)
-            vim.request('buffer_get_mark', vim.current.buffer, '.')
+            vim.request('nvim_err_write', 'ERROR\n', async=True)
+            vim.request('nvim_buf_get_mark', vim.current.buffer, '.')
 
 
         Normally a blocking request will be sent.  If the `async` flag is
@@ -205,38 +205,38 @@ class Nvim(object):
 
     def subscribe(self, event):
         """Subscribe to a Nvim event."""
-        return self.request('vim_subscribe', event)
+        return self.request('nvim_subscribe', event)
 
     def unsubscribe(self, event):
         """Unsubscribe to a Nvim event."""
-        return self.request('vim_unsubscribe', event)
+        return self.request('nvim_unsubscribe', event)
 
     def command(self, string, **kwargs):
         """Execute a single ex command."""
-        return self.request('vim_command', string, **kwargs)
+        return self.request('nvim_command', string, **kwargs)
 
     def command_output(self, string):
         """Execute a single ex command and return the output."""
-        return self.request('vim_command_output', string)
+        return self.request('nvim_command_output', string)
 
     def eval(self, string, **kwargs):
         """Evaluate a vimscript expression."""
-        return self.request('vim_eval', string, **kwargs)
+        return self.request('nvim_eval', string, **kwargs)
 
     def call(self, name, *args, **kwargs):
         """Call a vimscript function."""
-        return self.request('vim_call_function', name, args, **kwargs)
+        return self.request('nvim_call_function', name, args, **kwargs)
 
     def strwidth(self, string):
         """Return the number of display cells `string` occupies.
 
         Tab is counted as one cell.
         """
-        return self.request('vim_strwidth', string)
+        return self.request('nvim_strwidth', string)
 
     def list_runtime_paths(self):
         """Return a list of paths contained in the 'runtimepath' option."""
-        return self.request('vim_list_runtime_paths')
+        return self.request('nvim_list_runtime_paths')
 
     def foreach_rtp(self, cb):
         """Invoke `cb` for each path in 'runtimepath'.
@@ -246,7 +246,7 @@ class Nvim(object):
         are no longer paths. If stopped in case callable returned non-None,
         vim.foreach_rtp function returns the value returned by callable.
         """
-        for path in self.request('vim_list_runtime_paths'):
+        for path in self.request('nvim_list_runtime_paths'):
             try:
                 if cb(path) is not None:
                     break
@@ -256,7 +256,7 @@ class Nvim(object):
     def chdir(self, dir_path):
         """Run os.chdir, then all appropriate vim stuff."""
         os_chdir(dir_path)
-        return self.request('vim_change_directory', dir_path)
+        return self.request('nvim_set_current_dir', dir_path)
 
     def feedkeys(self, keys, options='', escape_csi=True):
         """Push `keys` to Nvim user input buffer.
@@ -267,7 +267,7 @@ class Nvim(object):
         - 't': Handle keys as if typed; otherwise they are handled as if coming
                from a mapping. This matters for undo, opening folds, etc.
         """
-        return self.request('vim_feedkeys', keys, options, escape_csi)
+        return self.request('nvim_feedkeys', keys, options, escape_csi)
 
     def input(self, bytes):
         """Push `bytes` to Nvim low level input buffer.
@@ -277,7 +277,7 @@ class Nvim(object):
         written(which can be less than what was requested if the buffer is
         full).
         """
-        return self.request('vim_input', bytes)
+        return self.request('nvim_input', bytes)
 
     def replace_termcodes(self, string, from_part=False, do_lt=True,
                           special=True):
@@ -298,11 +298,11 @@ class Nvim(object):
 
     def out_write(self, msg):
         """Print `msg` as a normal message."""
-        return self.request('vim_out_write', msg)
+        return self.request('nvim_out_write', msg)
 
     def err_write(self, msg, **kwargs):
         """Print `msg` as an error message."""
-        return self.request('vim_err_write', msg, **kwargs)
+        return self.request('nvim_err_write', msg, **kwargs)
 
     def quit(self, quit_command='qa!'):
         """Send a quit command to Nvim.
@@ -359,7 +359,7 @@ class Buffers(object):
 
     def __init__(self, nvim):
         """Initialize a Buffers object with Nvim object `nvim`."""
-        self._fetch_buffers = nvim.api.get_buffers
+        self._fetch_buffers = nvim.api.list_bufs
 
     def __len__(self):
         """Return the count of buffers."""
@@ -399,35 +399,35 @@ class Current(object):
 
     @property
     def line(self):
-        return self._session.request('vim_get_current_line')
+        return self._session.request('nvim_get_current_line')
 
     @line.setter
     def line(self, line):
-        return self._session.request('vim_set_current_line', line)
+        return self._session.request('nvim_set_current_line', line)
 
     @property
     def buffer(self):
-        return self._session.request('vim_get_current_buffer')
+        return self._session.request('nvim_get_current_buf')
 
     @buffer.setter
     def buffer(self, buffer):
-        return self._session.request('vim_set_current_buffer', buffer)
+        return self._session.request('nvim_set_current_buf', buffer)
 
     @property
     def window(self):
-        return self._session.request('vim_get_current_window')
+        return self._session.request('nvim_get_current_win')
 
     @window.setter
     def window(self, window):
-        return self._session.request('vim_set_current_window', window)
+        return self._session.request('nvim_set_current_win', window)
 
     @property
     def tabpage(self):
-        return self._session.request('vim_get_current_tabpage')
+        return self._session.request('nvim_get_current_tabpage')
 
     @tabpage.setter
     def tabpage(self, tabpage):
-        return self._session.request('vim_set_current_tabpage', tabpage)
+        return self._session.request('nvim_set_current_tabpage', tabpage)
 
 
 class Funcs(object):

--- a/neovim/api/tabpage.py
+++ b/neovim/api/tabpage.py
@@ -8,7 +8,7 @@ __all__ = ('Tabpage')
 class Tabpage(Remote):
     """A remote Nvim tabpage."""
 
-    _api_prefix = "tabpage_"
+    _api_prefix = "nvim_tabpage_"
 
     def __init__(self, *args):
         """Initialize from session and code_data immutable object.
@@ -17,17 +17,17 @@ class Tabpage(Remote):
         msgpack-rpc calls. It must be immutable for Buffer equality to work.
         """
         super(Tabpage, self).__init__(*args)
-        self.windows = RemoteSequence(self, 'tabpage_get_windows')
+        self.windows = RemoteSequence(self, 'nvim_tabpage_list_wins')
 
     @property
     def window(self):
         """Get the `Window` currently focused on the tabpage."""
-        return self.request('tabpage_get_window')
+        return self.request('nvim_tabpage_get_win')
 
     @property
     def valid(self):
         """Return True if the tabpage still exists."""
-        return self.request('tabpage_is_valid')
+        return self.request('nvim_tabpage_is_valid')
 
     @property
     def number(self):

--- a/neovim/api/window.py
+++ b/neovim/api/window.py
@@ -9,62 +9,62 @@ class Window(Remote):
 
     """A remote Nvim window."""
 
-    _api_prefix = "window_"
+    _api_prefix = "nvim_win_"
 
     @property
     def buffer(self):
         """Get the `Buffer` currently being displayed by the window."""
-        return self.request('window_get_buffer')
+        return self.request('nvim_win_get_buf')
 
     @property
     def cursor(self):
         """Get the (row, col) tuple with the current cursor position."""
-        return self.request('window_get_cursor')
+        return self.request('nvim_win_get_cursor')
 
     @cursor.setter
     def cursor(self, pos):
         """Set the (row, col) tuple as the new cursor position."""
-        return self.request('window_set_cursor', pos)
+        return self.request('nvim_win_set_cursor', pos)
 
     @property
     def height(self):
         """Get the window height in rows."""
-        return self.request('window_get_height')
+        return self.request('nvim_win_get_height')
 
     @height.setter
     def height(self, height):
         """Set the window height in rows."""
-        return self.request('window_set_height', height)
+        return self.request('nvim_win_set_height', height)
 
     @property
     def width(self):
         """Get the window width in rows."""
-        return self.request('window_get_width')
+        return self.request('nvim_win_get_width')
 
     @width.setter
     def width(self, width):
         """Set the window height in rows."""
-        return self.request('window_set_width', width)
+        return self.request('nvim_win_set_width', width)
 
     @property
     def row(self):
         """0-indexed, on-screen window position(row) in display cells."""
-        return self.request('window_get_position')[0]
+        return self.request('nvim_win_get_position')[0]
 
     @property
     def col(self):
         """0-indexed, on-screen window position(col) in display cells."""
-        return self.request('window_get_position')[1]
+        return self.request('nvim_win_get_position')[1]
 
     @property
     def tabpage(self):
         """Get the `Tabpage` that contains the window."""
-        return self.request('window_get_tabpage')
+        return self.request('nvim_win_get_tabpage')
 
     @property
     def valid(self):
         """Return True if the window still exists."""
-        return self.request('window_is_valid')
+        return self.request('nvim_win_is_valid')
 
     @property
     def number(self):

--- a/neovim/util.py
+++ b/neovim/util.py
@@ -10,3 +10,23 @@ def format_exc_skip(skip, limit=None):
     for i in range(skip):
         tb = tb.tb_next
     return ('\n'.join(format_exception(type, val, tb, limit))).rstrip()
+
+
+# Taken from SimpleNamespace in python 3
+class Version:
+
+    """Helper class for version info."""
+
+    def __init__(self, **kwargs):
+        """Create the Version object."""
+        self.__dict__.update(kwargs)
+
+    def __repr__(self):
+        """Return str representation of the Version."""
+        keys = sorted(self.__dict__)
+        items = ("{}={!r}".format(k, self.__dict__[k]) for k in keys)
+        return "{}({})".format(type(self).__name__, ", ".join(items))
+
+    def __eq__(self, other):
+        """Check if version is same as other."""
+        return self.__dict__ == other.__dict__

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if platform.python_implementation() != 'PyPy':
     install_requires.append('greenlet')
 
 setup(name='neovim',
-      version='0.1.10',
+      version='0.1.11dev',
       description='Python client to neovim',
       url='http://github.com/neovim/python-client',
       download_url='https://github.com/neovim/python-client/archive/0.1.10.tar.gz',

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -83,8 +83,8 @@ def test_api():
     vim.current.buffer.api.set_var('myvar', 'thetext')
     eq(vim.current.buffer.api.get_var('myvar'), 'thetext')
     eq(vim.eval('b:myvar'), 'thetext')
-    vim.current.buffer.api.set_line_slice(0,-1,True,True,['alpha', 'beta'])
-    eq(vim.current.buffer.api.get_line_slice(0,-1,True,True), ['alpha', 'beta'])
+    vim.current.buffer.api.set_lines(0,-1,True,['alpha', 'beta'])
+    eq(vim.current.buffer.api.get_lines(0,-1,True), ['alpha', 'beta'])
     eq(vim.current.buffer[:], ['alpha', 'beta'])
 
 


### PR DESCRIPTION
Citing the nvim help:

> The Python client is the reference implementation for API clients. It is
always up-to-date with the Nvim API, so its source code and test suite are
authoritative references.

As the tests show, this is a slightly _breaking_ change for `obj.api.method(...)`. We could mitigate that by letting the `RemoteApi` contain a whitelist of deprecated and renamed methods, but I doubt that it would affect any plugin as all the functionality of the deprecated and renamed methods are more conveniently exposed through the standard (hard-coded) python interface.