### PR TITLE
Add number attribute to Window and Tabpage objects

### DIFF
--- a/neovim/api/tabpage.py
+++ b/neovim/api/tabpage.py
@@ -28,3 +28,8 @@ class Tabpage(Remote):
     def valid(self):
         """Return True if the tabpage still exists."""
         return self.request('tabpage_is_valid')
+
+    @property
+    def number(self):
+        """Get the tabpage number."""
+        return self.request('nvim_tabpage_get_number')

--- a/neovim/api/window.py
+++ b/neovim/api/window.py
@@ -65,3 +65,8 @@ class Window(Remote):
     def valid(self):
         """Return True if the window still exists."""
         return self.request('window_is_valid')
+
+    @property
+    def number(self):
+        """Get the window number."""
+        return self.request('nvim_win_get_number')

--- a/test/test_tabpage.py
+++ b/test/test_tabpage.py
@@ -28,3 +28,12 @@ def test_valid():
     ok(tabpage.valid)
     vim.command('tabclose')
     ok(not tabpage.valid)
+
+
+@with_setup(setup=cleanup)
+def test_number():
+    curnum = vim.current.tabpage.number
+    vim.command('tabnew')
+    eq(vim.current.tabpage.number, curnum + 1)
+    vim.command('tabnew')
+    eq(vim.current.tabpage.number, curnum + 2)

--- a/test/test_window.py
+++ b/test/test_window.py
@@ -94,3 +94,12 @@ def test_valid():
     ok(window.valid)
     vim.command('q')
     ok(not window.valid)
+
+
+@with_setup(setup=cleanup)
+def test_number():
+    curnum = vim.current.window.number
+    vim.command('bot split')
+    eq(vim.current.window.number, curnum + 1)
+    vim.command('bot split')
+    eq(vim.current.window.number, curnum + 2)


### PR DESCRIPTION
The legacy if_pyth interface exposed a number attribute which was
equivalent to the winnr() and tabpagenr() values for the window and
tabpage, respectively.

Neovim 0.1.6 added the necessary API functions to support exposing this
information.

Closes #87