### PR TITLE
api: export Object.handle and make Buffer.number non-blocking

### DIFF
--- a/neovim/api/buffer.py
+++ b/neovim/api/buffer.py
@@ -128,7 +128,7 @@ class Buffer(Remote):
     @property
     def number(self):
         """Get the buffer number."""
-        return self.request('nvim_buf_get_number')
+        return self.handle
 
 
 class Range(object):

--- a/neovim/api/common.py
+++ b/neovim/api/common.py
@@ -1,6 +1,8 @@
 """Code shared between the API classes."""
 import functools
 
+from msgpack import unpackb
+
 from ..compat import unicode_errors_default
 
 
@@ -21,6 +23,7 @@ class Remote(object):
         """
         self._session = session
         self.code_data = code_data
+        self.handle = unpackb(code_data[1])
         self.api = RemoteApi(self, self._api_prefix)
         self.vars = RemoteMap(self, self._api_prefix + 'get_var',
                               self._api_prefix + 'set_var')

--- a/test/test_window.py
+++ b/test/test_window.py
@@ -103,3 +103,17 @@ def test_number():
     eq(vim.current.window.number, curnum + 1)
     vim.command('bot split')
     eq(vim.current.window.number, curnum + 2)
+
+
+@with_setup(setup=cleanup)
+def test_handle():
+    hnd1 = vim.current.window.handle
+    vim.command('bot split')
+    hnd2 = vim.current.window.handle
+    ok(hnd2 != hnd1)
+    vim.command('bot split')
+    hnd3 = vim.current.window.handle
+    ok(hnd3 != hnd1)
+    ok(hnd3 != hnd2)
+    vim.command('wincmd w')
+    eq(vim.current.window.handle,hnd1)


### PR DESCRIPTION
In conversion with @justinmk (on gitter), we decided to "freeze" the current msgpack EXT representation objects, which simply is the handle (buffer number, window id) of the object. This means `nvim_buf_get_number` is very unneccesery, it takes the (doubly-encoded) number and just echoes the same number back, single-encoded.

This makes `buffer.number` deduce the number from the `code_data`, instead of using a blocking rpc call. This means it can be safely used in async handlers and threads, for instance buffer change notifications (neovim/neovim#5269) will send a buffer object in async notifications, but one might want to use the number for bookkeeping etc.

This also exposes Object.handle, I think it is very unlikely that vim will introduce something conflicting here, if anythink they might add `Window.winid` which we can alias the same way.