### PR TITLE
Attach child handler loop.

### DIFF
--- a/neovim/msgpack_rpc/event_loop/asyncio.py
+++ b/neovim/msgpack_rpc/event_loop/asyncio.py
@@ -93,6 +93,8 @@ class AsyncioEventLoop(BaseEventLoop, asyncio.Protocol,
         self._loop.run_until_complete(coroutine)
 
     def _connect_child(self, argv):
+        self._child_watcher = asyncio.get_child_watcher()
+        self._child_watcher.attach_loop(self._loop)
         coroutine = self._loop.subprocess_exec(self._fact, *argv)
         self._loop.run_until_complete(coroutine)
 


### PR DESCRIPTION
Fix problems reported in #238 for Python3.6. ( In python3.5 I couldn't reproduce the error)
Tested with python versions: 2.7.13, 3.4.5, 3.5.2 and 3.6.0.

In python 3.4, and 3.5, we have this:
```
Exception ignored in: <bound method _UnixSelectorEventLoop.__del__ of <_UnixSelectorEventLoop running=False closed=True debug=False>>
Traceback (most recent call last):
  File "/home/meiralins/.pyenv/versions/3.4.5/lib/python3.4/asyncio/base_events.py", line 417, in __del__
  File "/home/meiralins/.pyenv/versions/3.4.5/lib/python3.4/asyncio/unix_events.py", line 58, in close
  File "/home/meiralins/.pyenv/versions/3.4.5/lib/python3.4/asyncio/unix_events.py", line 139, in remove_signal_handler
TypeError: signal handler must be signal.SIG_IGN, signal.SIG_DFL, or a callable object
Exception ignored in: Exception ignored in: Exception ignored in: %
```

```
Exception ignored in: <bound method BaseEventLoop.__del__ of <_UnixSelectorEventLoop running=False closed=True debug=False>>
Traceback (most recent call last):
  File "/home/meiralins/.pyenv/versions/3.5.2/lib/python3.5/asyncio/base_events.py", line 431, in __del__
  File "/home/meiralins/.pyenv/versions/3.5.2/lib/python3.5/asyncio/unix_events.py", line 58, in close
  File "/home/meiralins/.pyenv/versions/3.5.2/lib/python3.5/asyncio/unix_events.py", line 139, in remove_signal_handler
  File "/home/meiralins/.pyenv/versions/3.5.2/lib/python3.5/signal.py", line 47, in signal
TypeError: signal handler must be signal.SIG_IGN, signal.SIG_DFL, or a callable object
```

I'm not sure how to fix it yet.