### PR TITLE
win: setup.py: Require pyuv on old python only.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,12 @@ extras_require = {
     'pyuv': ['pyuv>=1.0.0'],
 }
 
-if os.name == 'nt':
-    install_requires.append('pyuv>=1.0.0')
-elif sys.version_info < (3, 4):
-    # trollius is just a backport of 3.4 asyncio module
-    install_requires.append('trollius')
+if sys.version_info < (3, 4):
+    if os.name == 'nt':
+        install_requires.append('pyuv>=1.0.0')
+    else:
+        # trollius is just a backport of 3.4 asyncio module
+        install_requires.append('trollius')
 
 if platform.python_implementation() != 'PyPy':
     # pypy already includes an implementation of the greenlet module


### PR DESCRIPTION
@bfredl @brcolow In https://github.com/neovim/python-client/pull/203 it's not clear why pyuv is always needed on Windows, instead of only older python versions. Since asyncio is available on python 3.4+ and we [fall back](https://github.com/meiralins/python-client/blob/c165783367703d8a61b9a0f2b32f20c244ef567b/neovim/msgpack_rpc/event_loop/__init__.py#L8) to it, we shouldn't need to require it on Windows in the context of python 3.4+.

