### PR TITLE
Implementation of global function 'nvim_err_writeln'

### DIFF
--- a/neovim/api/nvim.py
+++ b/neovim/api/nvim.py
@@ -306,6 +306,13 @@ class Nvim(object):
         """Print `msg` as an error message."""
         return self.request('nvim_err_write', msg, **kwargs)
 
+    def err_writeln(self, msg, **kwargs):
+        """Print `msg` as an error message.
+
+        Appends a `linefeed` to ensure all contents are writen.
+        """
+        return self.request('nvim_err_writeln', msg, **kwargs)
+
     def quit(self, quit_command='qa!'):
         """Send a quit command to Nvim.
 


### PR DESCRIPTION
Hi, the global function `nvim_err_writeln` was missing, so I added it. I took the documentation from the [neovim docs](https://github.com/neovim/neovim/blob/master/runtime/doc/api.txt#L295).

Sorry I haven't added any test, I don't know how to test this functionality and I didn't find any similar test.