### PR TITLE
Raise end-index by 1 when setting parts of Range

### DIFF
--- a/neovim/api/buffer.py
+++ b/neovim/api/buffer.py
@@ -160,8 +160,8 @@ class Range(object):
         if start is None:
             start = self.start
         if end is None:
-            end = self.end + 1
-        self._buffer[start:end] = lines
+            end = self.end
+        self._buffer[start:end + 1] = lines
 
     def __iter__(self):
         for i in range(self.start, self.end + 1):

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -172,3 +172,10 @@ def test_get_exceptions():
 @with_setup(setup=cleanup)
 def test_contains():
     ok(vim.current.buffer in vim.buffers)
+
+@with_setup(setup=cleanup)
+def test_set_items_for_range():
+    vim.current.buffer[:] = ['a', 'b', 'c', 'd', 'e']
+    r = vim.current.buffer.range(1, 3)
+    r[1:3] = ['foo']*3
+    eq(vim.current.buffer[:], ['a', 'foo', 'foo', 'foo', 'd', 'e'])


### PR DESCRIPTION
This commit fixes a bug in Range, leading to the last line of a Range
not being able to be replaced via `__setitem__` as the final
line setting its contents in the buffer the Range is based on assumes the
end-index to be inclusive, which it isn't in Python-slicing-notation.

@justinmk 