### PR TITLE
Ignore D401-type-complaints of flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [flake8]
-ignore = D211,E731,F821
+ignore = D211,E731,F821,D401


### PR DESCRIPTION
Travis-CI-Build currently fails on the codebase of `python-client` in general for all PRs (except this one fixing the issue), because D401 of `flake8` complains about D401 at certain positions.
This adds D401 to the ignore-list in `setup.cfg` to avoid this.