### PR TITLE
[WIP] [RFC] feature: add notification handler for python_execute

### DIFF
--- a/neovim/plugin/script_host.py
+++ b/neovim/plugin/script_host.py
@@ -84,6 +84,7 @@ class ScriptHost(object):
 
     @rpc_export('python_execute_async', sync=False)
     def python_execute_async(self, *args):
+        """Same as python_execute, except it's notification handler."""
         try:
             self.python_execute(*args)
         except Exception:
@@ -103,6 +104,7 @@ class ScriptHost(object):
 
     @rpc_export('python_execute_file_async', sync=False)
     def python_execute_file_async(self, *args):
+        """Same as python_execute_file, except it's notification handler."""
         try:
             self.python_execute(*args)
         except Exception as ex:

--- a/neovim/plugin/script_host.py
+++ b/neovim/plugin/script_host.py
@@ -14,7 +14,10 @@ __all__ = ('ScriptHost',)
 
 
 logger = logging.getLogger(__name__)
-debug, info, warn = (logger.debug, logger.info, logger.warn,)
+debug, info, warn, exception = (logger.debug,
+                                logger.info,
+                                logger.warn,
+                                logger.exception)
 
 IS_PYTHON3 = sys.version_info >= (3, 0)
 
@@ -79,6 +82,14 @@ class ScriptHost(object):
         except Exception:
             raise ErrorResponse(format_exc_skip(1))
 
+    @rpc_export('python_execute_async', sync=False)
+    def python_execute_async(self, *args):
+        try:
+            self.python_execute(*args)
+        except Exception:
+            exception('python_execute failed')
+            pass
+
     @rpc_export('python_execute_file', sync=True)
     def python_execute_file(self, file_path, range_start, range_stop):
         """Handle the `pyfile` ex command."""
@@ -89,6 +100,14 @@ class ScriptHost(object):
                 exec(script, self.module.__dict__)
             except Exception:
                 raise ErrorResponse(format_exc_skip(1))
+
+    @rpc_export('python_execute_file_async', sync=False)
+    def python_execute_file_async(self, *args):
+        try:
+            self.python_execute(*args)
+        except Exception as ex:
+            exception('python_execute_file failed')
+            pass
 
     @rpc_export('python_do_range', sync=True)
     def python_do_range(self, start, stop, code):


### PR DESCRIPTION
This PR is for supporting https://github.com/roxma/nvim-asyncscript

However, there's an issue with this PR, I need some help:

Here are the steps to reproduce the issue:

1. Print a very long string with `call ascript#python3("vim.command('echo &rtp')")`

2. Press `CTRL-C` to interrupt the command

The command line shows error message:

```
During handling of the above exception, another exception occurred:
Press ENTER or type command to continue
```

3. Print another very long string with `call ascript#python3("vim.command('echo &rtp')")`

Neovim says the channel is dead.

```
Error detected while processing function ascript#python3:
line    6:
E475: Invalid argument: Channel doesn't exist
```
