### PR TITLE
always use utf-8 encoding instead of locale.getpreferredencoding()

### DIFF
--- a/neovim/__init__.py
+++ b/neovim/__init__.py
@@ -119,7 +119,7 @@ def setup_logging(name):
         prefix = os.environ['NVIM_PYTHON_LOG_FILE'].strip()
         major_version = sys.version_info[0]
         logfile = '{}_py{}_{}'.format(prefix, major_version, name)
-        handler = logging.FileHandler(logfile, 'w')
+        handler = logging.FileHandler(logfile, 'w', 'utf-8')
         handler.formatter = logging.Formatter(
             '%(asctime)s [%(levelname)s @ '
             '%(filename)s:%(funcName)s:%(lineno)s] %(process)s - %(message)s')


### PR DESCRIPTION
https://github.com/roxma/nvim-completion-manager/issues/148#issuecomment-337771822

To avoid error on systems with non unicode compatible encoding returned by `locale.getpreferredencoding()`