### PR TITLE
[Proposal,WIP] change indexing-style in Range-Object-creation

### DIFF
--- a/neovim/api/buffer.py
+++ b/neovim/api/buffer.py
@@ -134,7 +134,7 @@ class Buffer(Remote):
 class Range(object):
     def __init__(self, buffer, start, end):
         self._buffer = buffer
-        self.start = start - 1
+        self.start = start
         self.end = end - 1
 
     def __len__(self):

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -176,6 +176,6 @@ def test_contains():
 @with_setup(setup=cleanup)
 def test_set_items_for_range():
     vim.current.buffer[:] = ['a', 'b', 'c', 'd', 'e']
-    r = vim.current.buffer.range(1, 3)
+    r = vim.current.buffer.range(0, 3)
     r[1:3] = ['foo']*3
     eq(vim.current.buffer[:], ['a', 'foo', 'foo', 'foo', 'd', 'e'])


### PR DESCRIPTION
This commit changes the indexing-style when creating a Range-object
from vim-style to Python-style, i.e. creating a Range-object spanning
the first three lines of a buffer changes from Range(buffer, 1, 3) to
Range(buffer, 0, 3), making the notation consistent with
Python-style-indexing and the behavior of the Buffer-object, that
already follows Python-style indexing.

Otherwise, addressing lines in a buffer via buffer[a:b] is inconsistent with buffer.range(a:b) as both do not return the same subset of lines, which is confusing and does not follow the principle of least surprise. Furthermore, range itself is afterwards indexed starting with 0, so the first line of `myrange` is `myrange[0]`, adding to the inconsistency.

Upstreams thoughts on the matter?

If this is considered mergeable, I'll take care of restructuring the rest of the range-object to internally work correctly with the changed constructor-notation in `__getitem__` and `__setitem__` and all other relevant cases.