### PR TITLE
tests: fix test_command_output

### DIFF
--- a/test/test_vim.py
+++ b/test/test_vim.py
@@ -26,10 +26,8 @@ def test_command():
     os.unlink(fname)
 
 
-@with_setup
 def test_command_output():
-    eq(vim.command_output('echo test'), 'test')
-
+    eq(vim.command_output('echon "test"'), 'test')
 
 @with_setup(setup=cleanup)
 def test_eval():


### PR DESCRIPTION
1. The `with_setup` decorator does not appear to be designed to be used
   without parenthesis.  Remove it, since it is not needed/used anyway.
2. Fix the actual test.