### PR TITLE
Setup: don't use transition package as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 from setuptools import setup
 
 install_requires = [
-    'msgpack-python>=0.4.0',
+    'msgpack>=0.5.0',
 ]
 extras_require = {
     'pyuv': ['pyuv>=1.0.0'],


### PR DESCRIPTION
The official package was renamed to `msgpack` whereas `msgpack-python` still acts as a transition package for it.

Relevant commits:

- https://github.com/msgpack/msgpack-python/commit/89e4f8b7b3a43fc84ea0dd278a4b8b54b1fac4bd
- https://github.com/msgpack/msgpack-python/commit/9f4c12f29ce7a6d62423311ab12a031dc79c458a
- https://github.com/msgpack/msgpack-python/commit/5be93786404d4e95de933d1bc64640402c3f2696