### PR TITLE
Fix VimPathFinder.find_spec (Python 3.4+)

### DIFF
--- a/neovim/plugin/script_host.py
+++ b/neovim/plugin/script_host.py
@@ -227,8 +227,10 @@ def path_hook(nvim):
 
         def load_module(self, fullname, path=None):
             # Check sys.modules, required for reload (see PEP302).
-            if fullname in sys.modules:
+            try:
                 return sys.modules[fullname]
+            except KeyError:
+                pass
             return imp.load_module(fullname, *self.module)
 
     class VimPathFinder(object):

--- a/neovim/plugin/script_host.py
+++ b/neovim/plugin/script_host.py
@@ -242,9 +242,9 @@ def path_hook(nvim):
                 return None
 
         @staticmethod
-        def find_spec(fullname, path=None, target=None):
+        def find_spec(fullname, target=None):
             """Method for Python 3.4+."""
-            return PathFinder.find_spec(fullname, path or _get_paths(), target)
+            return PathFinder.find_spec(fullname, _get_paths(), target)
 
     def hook(path):
         if path == nvim.VIM_SPECIAL_PATH:


### PR DESCRIPTION
The fix is similar to what VimModuleLoader.find_module does already.