### PR TITLE
Check count for 'not None' instead of truthy in command decorator

### DIFF
--- a/neovim/plugin/decorators.py
+++ b/neovim/plugin/decorators.py
@@ -55,7 +55,7 @@ def command(name, nargs=0, complete=None, range=None, count=None, bang=False,
 
         if range is not None:
             opts['range'] = '' if range is True else str(range)
-        elif count:
+        elif count is not None:
             opts['count'] = count
 
         if bang:

--- a/test/test_decorators.py
+++ b/test/test_decorators.py
@@ -1,0 +1,30 @@
+from nose.tools import with_setup, eq_ as eq, ok_ as ok
+
+from neovim.plugin.decorators import command
+
+
+def test_command_count():
+    def function():
+        "A dummy function to decorate."
+        return
+
+    # ensure absence with default value of None
+    decorated = command('test')(function)
+    ok('count' not in decorated._nvim_rpc_spec['opts'])
+
+    # ensure absence with explicit value of None
+    count_value = None
+    decorated = command('test', count=count_value)(function)
+    ok('count' not in decorated._nvim_rpc_spec['opts'])
+
+    # Test presesence with value of 0
+    count_value = 0
+    decorated = command('test', count=count_value)(function)
+    ok('count' in decorated._nvim_rpc_spec['opts'])
+    eq(decorated._nvim_rpc_spec['opts']['count'], count_value)
+
+    # Test presence with value of 1
+    count_value = 1
+    decorated = command('test', count=count_value)(function)
+    ok('count' in decorated._nvim_rpc_spec['opts'])
+    eq(decorated._nvim_rpc_spec['opts']['count'], count_value)


### PR DESCRIPTION
The command decorator was only checking the truthyness of `count`, which
meant that a value of 0 was considered falsy and so the value not passed
to the decorated function. A value of 0 for `count` should be valid
since this is the default in both vim and neovim (see `help v:count`).