### PR TITLE
Support msgpack 0.5.2

### DIFF
--- a/neovim/msgpack_rpc/msgpack_stream.py
+++ b/neovim/msgpack_rpc/msgpack_stream.py
@@ -20,7 +20,7 @@ class MsgpackStream(object):
     def __init__(self, event_loop):
         """Wrap `event_loop` on a msgpack-aware interface."""
         self._event_loop = event_loop
-        self._packer = Packer(unicode_errors=unicode_errors_default)
+        self._packer = Packer()
         self._unpacker = Unpacker()
         self._message_cb = None
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 from setuptools import setup
 
 install_requires = [
-    'msgpack>=0.5.0',
+    'msgpack>=0.5.2',
 ]
 extras_require = {
     'pyuv': ['pyuv>=1.0.0'],


### PR DESCRIPTION
msgpack 0.5.2 deprecated the `unicode_errors` parameter. Without this change, the following error occurs:

```
function provider#python3#Call[9]..remote#host#Require[10]..provider#pythonx#Require, line 15
Vim(if):ch 1 was closed by the client
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/andrewr/Library/Python/3.6/lib/python/site-packages/neovim/__init__.py", line 70, in start_host
    session = stdio_session()
  File "/Users/andrewr/Library/Python/3.6/lib/python/site-packages/neovim/msgpack_rpc/__init__.py", line 37, in stdio_session
    return session('stdio')
  File "/Users/andrewr/Library/Python/3.6/lib/python/site-packages/neovim/msgpack_rpc/__init__.py", line 19, in session
    msgpack_stream = MsgpackStream(loop)
  File "/Users/andrewr/Library/Python/3.6/lib/python/site-packages/neovim/msgpack_rpc/msgpack_stream.py", line 23, in __init__
    self._packer = Packer(unicode_errors=unicode_errors_default)
  File "msgpack/_packer.pyx", line 136, in msgpack._packer.Packer.__init__
TypeError: expected bytes, str found
Failed to load python3 host. You can try to see what happened by starting nvim with $NVIM_PYTHON_LOG_FILE set and opening the generated log file. Also, the host stderr is available in messages.
Press ENTER or type command to continue
```

**OS**: macOS 10.12.6
**Python**: 3.6.4
**NeoVim**: 0.2.2
**python-client**: 0.2.0