### PR TITLE
msgpack: specify encoding togheter with unicode_errors

### DIFF
--- a/neovim/msgpack_rpc/msgpack_stream.py
+++ b/neovim/msgpack_rpc/msgpack_stream.py
@@ -20,7 +20,8 @@ class MsgpackStream(object):
     def __init__(self, event_loop):
         """Wrap `event_loop` on a msgpack-aware interface."""
         self._event_loop = event_loop
-        self._packer = Packer(unicode_errors=unicode_errors_default)
+        self._packer = Packer(encoding='utf-8',
+                              unicode_errors=unicode_errors_default)
         self._unpacker = Unpacker()
         self._message_cb = None
 


### PR DESCRIPTION
temporary fix for msgpack-python 0.5.2

fixes #299