### PR TITLE
event loop: disable asyncio on windows for now

### DIFF
--- a/neovim/api/nvim.py
+++ b/neovim/api/nvim.py
@@ -97,7 +97,7 @@ class Nvim(object):
         self._err_cb = err_cb
 
         # only on python3.4+ we expose asyncio
-        if IS_PYTHON3:
+        if IS_PYTHON3 and os.name != 'nt':
             self.loop = self._session.loop._loop
 
     def _from_nvim(self, obj, decode=None):

--- a/neovim/msgpack_rpc/event_loop/__init__.py
+++ b/neovim/msgpack_rpc/event_loop/__init__.py
@@ -3,10 +3,12 @@
 Tries to use pyuv as a backend, falling back to the asyncio implementation.
 """
 
+import os
+
 from ...compat import IS_PYTHON3
 
 # on python3 we only support asyncio, as we expose it to plugins
-if IS_PYTHON3:
+if IS_PYTHON3 and os.name != 'nt':
     from .asyncio import AsyncioEventLoop
     EventLoop = AsyncioEventLoop
 else:

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,11 @@ install_requires = [
     'msgpack>=0.5.0',
 ]
 
-if sys.version_info < (3, 4):
-    if os.name == 'nt':
-        install_requires.append('pyuv>=1.0.0')
-    else:
-        # trollius is just a backport of 3.4 asyncio module
-        install_requires.append('trollius')
+if os.name == 'nt':
+    install_requires.append('pyuv>=1.0.0')
+elif sys.version_info < (3, 4):
+    # trollius is just a backport of 3.4 asyncio module
+    install_requires.append('trollius')
 
 if platform.python_implementation() != 'PyPy':
     # pypy already includes an implementation of the greenlet module


### PR DESCRIPTION
Disable asyncio on windows for now. `nvim.loop` will only be available on POSIX until stdio is fixed (hopefully soon).