### PR TITLE
Add lua integration (and update_highlights as an useful example)

### DIFF
--- a/neovim/api/buffer.py
+++ b/neovim/api/buffer.py
@@ -112,6 +112,29 @@ class Buffer(Remote):
         self.request('nvim_buf_clear_highlight', src_id,
                      line_start, line_end, async_=async_)
 
+    def update_highlights(self, src_id, hls, clear_start=0, clear_end=-1,
+                          clear=False, async_=True):
+        """Add or update highlights in batch to avoid unnecessary redraws.
+
+        A `src_id` must have been allocated prior to use of this function. Use
+        for instance `nvim.new_highlight_source()` to get a src_id for your
+        plugin.
+
+        `hls` should be a list of highlight items. Each item should be a list
+        or tuple on the form `("GroupName", linenr, col_start, col_end)` or
+        `("GroupName", linenr)` to highlight an entire line.
+
+        By default existing highlights are preserved. Specify a line range with
+        clear_start and clear_end to replace highlights in this range. As a
+        shorthand, use clear=True to clear the entire buffer before adding the
+        new highlights.
+        """
+        if clear and clear_start is None:
+            clear_start = 0
+        lua = self._session._get_lua_private()
+        lua.update_highlights(self, src_id, hls, clear_start, clear_end,
+                              async_=async_)
+
     @property
     def name(self):
         """Get the buffer name."""

--- a/neovim/compat.py
+++ b/neovim/compat.py
@@ -40,7 +40,7 @@ NUM_TYPES = (int, long, float)
 
 
 def check_async(async_, kwargs, default):
-    """Return a value of 'async' in kwargs or default when async_ is None
+    """Return a value of 'async' in kwargs or default when async_ is None.
 
     This helper function exists for backward compatibility (See #274).
     It shows a warning message when 'async' in kwargs is used to note users.

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -161,3 +161,10 @@ def test_set_items_for_range(vim):
     r = vim.current.buffer.range(1, 3)
     r[1:3] = ['foo']*3
     assert vim.current.buffer[:] == ['a', 'foo', 'foo', 'foo', 'd', 'e']
+
+# NB: we can't easily test the effect of this. But at least run the lua
+# function sync, so we know it runs without runtime error with simple args.
+def test_update_highlights(vim):
+    vim.current.buffer[:] = ['a', 'b', 'c']
+    src_id = vim.new_highlight_source()
+    vim.current.buffer.update_highlights(src_id, [["Comment", 0, 0, -1], ("String", 1, 0, 1)], clear=True, async_=False)

--- a/test/test_vim.py
+++ b/test/test_vim.py
@@ -168,3 +168,32 @@ def test_cwd(vim, tmpdir):
     cwd_python = vim.command_output('{} print(os.getcwd())'.format(pycmd))
     assert cwd_python == cwd_vim
     assert cwd_python != cwd_before
+
+lua_code = """
+local a = vim.api
+local y = ...
+function pynvimtest_func(x)
+    return x+y
+end
+
+local function setbuf(buf,lines)
+   a.nvim_buf_set_lines(buf, 0, -1, true, lines)
+end
+
+
+local function getbuf(buf)
+   return a.nvim_buf_line_count(buf)
+end
+
+pynvimtest = {setbuf=setbuf,getbuf=getbuf}
+
+return "eggspam"
+"""
+
+def test_lua(vim):
+  assert vim.exec_lua(lua_code, 7) == "eggspam"
+  assert vim.lua.pynvimtest_func(3) == 10
+  testmod = vim.lua.pynvimtest
+  buf = vim.current.buffer
+  testmod.setbuf(buf, ["a", "b", "c", "d"], async_=True)
+  assert testmod.getbuf(buf) == 4


### PR DESCRIPTION
Async rplugins (and sync ones for that matter) should conveniently be able to use lua to execute some logic on the nvim side. Rplugins can use `exec_lua(""" ....  _myplugin = {...}""")` or `exec_lua('_myplugin = require("myplugin")')` to define a module with helper functions, and then use `nvim.lua._myplugin.myfunction(..., [async=True])`  to call it.

The `update_highlights` shows an example of the helper function pattern. Though it gets a bit more complex  as we expect multiple copies of the python host, ordinary rplugins need not add the channel_id to the module name like the host does. nvim-ipy will add a more simple example how this can look for an rplugin.