### PR TITLE
docs for the next release (0.2.5)

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -19,18 +19,18 @@ in order for Neovim to use it for the plugin host.
 
 To run the tests execute::
 
-    nosetests
+    pytest
 
 This will run the tests in an embedded instance of Neovim.
 If you want to test a different version than ``nvim`` in ``$PATH`` use::
 
-    NVIM_CHILD_ARGV='["/path/to/nvim", "-u", "NONE", "--embed"]' nosetests
+    NVIM_CHILD_ARGV='["/path/to/nvim", "-u", "NONE", "--embed"]' pytest
 
 Alternatively, if you want to see the state of nvim, you could use::
 
     export NVIM_LISTEN_ADDRESS=/tmp/nvimtest
     xterm -e "nvim -u NONE"&
-    nosetests
+    pytest
 
 But note you need to restart Neovim every time you run the tests!
 Substitute your favorite terminal emulator for ``xterm``.

--- a/docs/usage/python-plugin-api.rst
+++ b/docs/usage/python-plugin-api.rst
@@ -6,17 +6,7 @@ as well as a number of extensions to the python API.
 The API extensions are accessible no matter if the traditional ``:python`` interface or the new mechanism is used,
 as discussed on :doc:`remote-plugins`.
 
-``vim.funcs``
--------------
-
-Exposes vimscript functions (both builtin and global user defined functions) as a python namespace.
-For instance to set the value of a register:
-
-.. code-block:: python
-
-   vim.funcs.setreg('0', ["some", "text"], 'l')
-
-``vim.api``
+Nvim API methods: ``vim.api``
 -----------
 
 Exposes Neovim API methods.
@@ -32,7 +22,7 @@ Also, object methods can be called directly on their object:
 .. code-block:: python
 
    buf = vim.current.buffer
-   len = buf.api.line_count()
+   length = buf.api.line_count()
 
 calls ``nvim_buf_line_count``.
 Alternatively msgpack requests can be invoked directly:
@@ -40,7 +30,75 @@ Alternatively msgpack requests can be invoked directly:
 .. code-block:: python
 
    result = vim.request("nvim_strwith", "some text")
-   len = vim.request("nvim_buf_line_count", buf)
+   length = vim.request("nvim_buf_line_count", buf)
+
+Both ``vim.api`` and ``vim.request`` can take an ``async_=True`` keyword argument
+to instead send a msgpack notification. Nvim will execute the API method the
+same way, but python will not wait for it to finish, so the return value is
+unavailable.
+
+Vimscript functions: ``vim.funcs``
+-------------
+
+Exposes vimscript functions (both builtin and global user defined functions) as a python namespace.
+For instance to set the value of a register:
+
+.. code-block:: python
+
+   vim.funcs.setreg('0', ["some", "text"], 'l')
+
+These functions can also take the ``async_=True`` keyword argument, just like API
+methods.
+
+Lua integration
+-----------
+
+Python plugins can define and invoke lua code in Nvim's in-process lua
+interpreter. This is especially useful in asynchronous contexts, where an async
+event handler can schedule a complex operation with many api calls to be
+executed by nvim without interleaved processing of user input or other event
+sources (unless requested).
+
+The recommended usage is the following pattern. First use ``vim.exec_lua(code)``
+to define a module with lua functions:
+
+.. code-block:: python
+
+   vim.exec_lua("""
+      local a = vim.api
+      local function add(a,b)
+          return a+b
+      end
+
+      local function buffer_ticks()
+         local ticks = {}
+         for _, buf in ipairs(a.nvim_list_bufs()) do
+             ticks[#ticks+1] = a.nvim_buf_get_changedtick(buf)
+         end
+         return ticks
+      end
+
+      _testplugin = {add=add, buffer_ticks=buffer_ticks}
+   """)
+
+Alternatively, place the code in ``/lua/testplugin.lua`` under your plugin repo
+root, and use ``vim.exec_lua("_testplugin = require('testplugin')")``.
+In both cases, replace ``testplugin`` with a unique string based on your plugin
+name.
+
+Then, the module can be acessed as ``vim.lua._testplugin``.
+
+.. code-block:: python
+
+    mod = vim.lua._testplugin
+    mod.add(2,3) # => 5
+    mod.buffer_ticks() # => list of ticks
+
+These functions can also take the ``async_=True`` keyword argument, just like API
+methods.
+
+It is also possible to pass arguments directly to a code block. Using
+``vim.exec_lua(code, args...)``, the arguments will be available in lua as ``...``.
 
 Async calls
 -----------
@@ -58,7 +116,8 @@ Note that this code will still block the plugin host if it does long-running com
 Intensive computations should be done in a separate thread (or process),
 and ``vim.async_call`` can be used to send results back to Neovim.
 
-Some methods accept an ``async_`` keyword argument:
-``vim.eval``, ``vim.command``, ``vim.request`` as well as the ``vim.funcs`` and ``vim.api`` wrappers.
-When ``async_=True`` is passed the client will not wait for Neovim to complete the request
-(which also means that the return value is unavailable).
+Some methods accept an ``async_`` keyword argument: ``vim.eval``,
+``vim.command``, ``vim.request`` as well as the ``vim.funcs``, ``vim.api` and
+``vim.lua``` wrappers.  When ``async_=True`` is passed the client will not wait
+for Neovim to complete the request (which also means that the return value is
+unavailable).

--- a/docs/usage/remote-plugins.rst
+++ b/docs/usage/remote-plugins.rst
@@ -41,8 +41,17 @@ are blocked while a synchronous handler is running.
 This ensures that async handlers can call requests without Neovim confusing these requests with requests from a synchronous handler.
 To execute an asynchronous handler even when other handlers are running,
 add ``allow_nested=True`` to the decorator.
-The handler must then not make synchronous Neovim requests,
+This handler must then not make synchronous Neovim requests,
 but it can make asynchronous requests, i.e. passing ``async_=True``.
+
+.. note::
+
+    Plugins must not invoke API methods in ``__init__`` or global module scope
+    (or really do anything with non-trivial side-effects). A well-behaved rplugin
+    will not start executing until its functionality is requested by the user.
+    Initialize the plugin the first time the user invokes a command, or use an
+    appropriate autocommand, if it e.g. makes sense to automatically start the
+    plugin for a given filetype.
 
 You need to run ``:UpdateRemotePlugins`` in Neovim for changes in the specifications to have effect.
 For details see ``:help remote-plugin`` in Neovim.


### PR DESCRIPTION
Clean up README.md and use references to readthedocs. 

Start to use "pynvim" name more often in the docs. I will do a functional release first with py3.7 and lua support (0.2.5).  After that a separate release that _only_ does the formal rename, including updating the installation commands in the docs (0.2.6 or 0.3).