### PR TITLE
Fix PendingDeprecationWarning with Packer.encoding

### DIFF
--- a/neovim/msgpack_rpc/msgpack_stream.py
+++ b/neovim/msgpack_rpc/msgpack_stream.py
@@ -20,8 +20,7 @@ class MsgpackStream(object):
     def __init__(self, event_loop):
         """Wrap `event_loop` on a msgpack-aware interface."""
         self.loop = event_loop
-        self._packer = Packer(encoding='utf-8',
-                              unicode_errors=unicode_errors_default)
+        self._packer = Packer(unicode_errors=unicode_errors_default)
         self._unpacker = Unpacker()
         self._message_cb = None
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,7 @@
 [flake8]
 ignore = D211,E731,D401
+
+[tool:pytest]
+filterwarnings =
+    once::DeprecationWarning
+    once::PendingDeprecationWarning


### PR DESCRIPTION
Fixes:

  …/neovim-python-client/neovim/msgpack_rpc/msgpack_stream.py:24: PendingDeprecationWarning: encoding is deprecated.
    unicode_errors=unicode_errors_default)

Also configures pytest to display these warnings.